### PR TITLE
Add LLM summarization API and launcher dropdown (YTT-26, YTT-27)

### DIFF
--- a/app/api/transcripts/[id]/summarize/route.ts
+++ b/app/api/transcripts/[id]/summarize/route.ts
@@ -1,0 +1,205 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import type { TranscriptSegment } from "@/lib/types";
+
+interface SummarizeRequestBody {
+  provider: "openai" | "anthropic";
+  apiKey: string;
+  model?: string;
+  prompt?: string;
+  format?: "markdown" | "text" | "bullets";
+}
+
+const DEFAULT_MODELS: Record<string, string> = {
+  openai: "gpt-4o",
+  anthropic: "claude-sonnet-4-5-20250929",
+};
+
+const FORMAT_INSTRUCTIONS: Record<string, string> = {
+  markdown:
+    "Format your response as clean Markdown with headings and bullet points.",
+  text: "Format your response as plain text paragraphs.",
+  bullets:
+    "Format your response as a concise bullet-point list of the key points.",
+};
+
+function buildPrompt(
+  title: string,
+  transcript: string,
+  customPrompt?: string,
+  format: string = "markdown"
+): string {
+  if (customPrompt) return `${customPrompt}\n\nTranscript from "${title}":\n\n${transcript}`;
+
+  const formatInstruction = FORMAT_INSTRUCTIONS[format] || FORMAT_INSTRUCTIONS.markdown;
+
+  return [
+    `Summarize the following transcript from "${title}".`,
+    formatInstruction,
+    "Focus on the main topics, key insights, and any actionable takeaways.",
+    "",
+    "Transcript:",
+    "",
+    transcript,
+  ].join("\n");
+}
+
+function flattenTranscript(segments: TranscriptSegment[]): string {
+  return segments.map((s) => s.text).join(" ");
+}
+
+async function callOpenAI(
+  apiKey: string,
+  model: string,
+  prompt: string
+): Promise<{ summary: string; model_used: string; usage: { prompt_tokens: number; completion_tokens: number } }> {
+  const res = await fetch("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model,
+      messages: [{ role: "user", content: prompt }],
+      temperature: 0.3,
+    }),
+  });
+
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    const message = err?.error?.message || `OpenAI API error (${res.status})`;
+    throw new Error(message);
+  }
+
+  const data = await res.json();
+  return {
+    summary: data.choices[0]?.message?.content ?? "",
+    model_used: data.model,
+    usage: {
+      prompt_tokens: data.usage?.prompt_tokens ?? 0,
+      completion_tokens: data.usage?.completion_tokens ?? 0,
+    },
+  };
+}
+
+async function callAnthropic(
+  apiKey: string,
+  model: string,
+  prompt: string
+): Promise<{ summary: string; model_used: string; usage: { prompt_tokens: number; completion_tokens: number } }> {
+  const res = await fetch("https://api.anthropic.com/v1/messages", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": apiKey,
+      "anthropic-version": "2023-06-01",
+    },
+    body: JSON.stringify({
+      model,
+      max_tokens: 4096,
+      messages: [{ role: "user", content: prompt }],
+    }),
+  });
+
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    const message = err?.error?.message || `Anthropic API error (${res.status})`;
+    throw new Error(message);
+  }
+
+  const data = await res.json();
+  const text = data.content
+    ?.filter((c: { type: string }) => c.type === "text")
+    .map((c: { text: string }) => c.text)
+    .join("") ?? "";
+
+  return {
+    summary: text,
+    model_used: data.model,
+    usage: {
+      prompt_tokens: data.usage?.input_tokens ?? 0,
+      completion_tokens: data.usage?.output_tokens ?? 0,
+    },
+  };
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  // Validate request body
+  let body: SummarizeRequestBody;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { provider, apiKey, model, prompt: customPrompt, format = "markdown" } = body;
+
+  if (!provider || !["openai", "anthropic"].includes(provider)) {
+    return NextResponse.json(
+      { error: 'provider must be "openai" or "anthropic"' },
+      { status: 400 }
+    );
+  }
+
+  if (!apiKey || typeof apiKey !== "string") {
+    return NextResponse.json(
+      { error: "apiKey is required" },
+      { status: 400 }
+    );
+  }
+
+  if (!["markdown", "text", "bullets"].includes(format)) {
+    return NextResponse.json(
+      { error: 'format must be "markdown", "text", or "bullets"' },
+      { status: 400 }
+    );
+  }
+
+  // Fetch transcript
+  const video = await prisma.video.findUnique({ where: { id } });
+  if (!video) {
+    return NextResponse.json({ error: "Transcript not found" }, { status: 404 });
+  }
+
+  const segments: TranscriptSegment[] = JSON.parse(video.transcript);
+  if (segments.length === 0) {
+    return NextResponse.json(
+      { error: "Transcript is empty" },
+      { status: 400 }
+    );
+  }
+
+  const transcriptText = flattenTranscript(segments);
+  const resolvedModel = model || DEFAULT_MODELS[provider];
+  const fullPrompt = buildPrompt(video.title, transcriptText, customPrompt, format);
+
+  try {
+    const callProvider = provider === "openai" ? callOpenAI : callAnthropic;
+    const result = await callProvider(apiKey, resolvedModel, fullPrompt);
+
+    return NextResponse.json({
+      summary: result.summary,
+      model_used: result.model_used,
+      provider,
+      format,
+      token_count: {
+        prompt_tokens: result.usage.prompt_tokens,
+        completion_tokens: result.usage.completion_tokens,
+      },
+      video: {
+        id: video.id,
+        title: video.title,
+        videoUrl: video.videoUrl,
+      },
+    });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : "Summarization failed";
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,6 +7,7 @@ import type { TranscriptSegment } from "@/lib/types";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { IconButton, iconButtonClassName } from "@/components/ui/icon-button";
+import { LlmLauncher } from "@/components/ui/llm-launcher";
 
 interface QueueItem {
   url: string;
@@ -125,6 +126,7 @@ function HomeInner() {
 
   const [deleteId, setDeleteId] = useState<string | null>(null);
   const [deleting, setDeleting] = useState(false);
+  const [toast, setToast] = useState<string | null>(null);
   const [debugEvents, setDebugEvents] = useState<DebugEvent[]>([]);
   const [debugPaused, setDebugPaused] = useState(false);
   const [debugCollapsed, setDebugCollapsed] = useState(false);
@@ -930,6 +932,14 @@ function HomeInner() {
                               </button>
 
                               <div className="flex shrink-0 items-center gap-2 opacity-0 transition-opacity group-hover/row:opacity-100">
+                                <LlmLauncher
+                                  videoId={t.id}
+                                  videoTitle={t.title}
+                                  onToast={(msg) => {
+                                    setToast(msg);
+                                    setTimeout(() => setToast(null), 2500);
+                                  }}
+                                />
                                 <a
                                   href={`/api/transcripts/${t.id}/download`}
                                   title="Download as Markdown"
@@ -1141,6 +1151,13 @@ function HomeInner() {
           )}
         </div>
       </div>
+
+      {/* Toast notification */}
+      {toast && (
+        <div className="fixed bottom-6 left-1/2 z-50 -translate-x-1/2 rounded-lg border border-white/15 bg-[hsl(var(--panel))] px-4 py-2.5 text-sm text-white/80 shadow-[0_20px_60px_-15px_rgba(0,0,0,0.7)]">
+          {toast}
+        </div>
+      )}
 
       {/* Delete confirmation dialog */}
       {deleteId && (

--- a/components/ui/llm-launcher.tsx
+++ b/components/ui/llm-launcher.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { useState, useRef, useEffect, useCallback } from "react";
+
+interface LlmProvider {
+  id: string;
+  name: string;
+  /** URL template — `{prompt}` is replaced with encoded prompt text */
+  urlTemplate: string | null;
+  /** If true, copies prompt to clipboard instead of URL-encoding it */
+  clipboardFallback: boolean;
+}
+
+const PROVIDERS: LlmProvider[] = [
+  {
+    id: "chatgpt",
+    name: "ChatGPT",
+    urlTemplate: "https://chatgpt.com/?q={prompt}",
+    clipboardFallback: false,
+  },
+  {
+    id: "claude",
+    name: "Claude",
+    urlTemplate: null,
+    clipboardFallback: true,
+  },
+];
+
+const OPEN_URLS: Record<string, string> = {
+  claude: "https://claude.ai/new",
+};
+
+const STORAGE_KEY = "llm-launcher-last-provider";
+
+function buildSummarizePrompt(title: string, transcript: string): string {
+  return `Summarize the following transcript from "${title}". Focus on the main topics, key insights, and any actionable takeaways.\n\nTranscript:\n\n${transcript}`;
+}
+
+interface LlmLauncherProps {
+  videoId: string;
+  videoTitle: string;
+  onToast?: (message: string) => void;
+}
+
+export function LlmLauncher({ videoId, videoTitle, onToast }: LlmLauncherProps) {
+  const [open, setOpen] = useState(false);
+  const [lastProvider, setLastProvider] = useState<string | null>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setLastProvider(localStorage.getItem(STORAGE_KEY));
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    function handleClickOutside(e: MouseEvent) {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [open]);
+
+  const launchWithProvider = useCallback(
+    async (provider: LlmProvider) => {
+      setOpen(false);
+      localStorage.setItem(STORAGE_KEY, provider.id);
+      setLastProvider(provider.id);
+
+      // Fetch full transcript text
+      let transcriptText: string;
+      try {
+        const res = await fetch(`/api/transcripts/${videoId}`);
+        if (!res.ok) {
+          onToast?.("Failed to load transcript");
+          return;
+        }
+        const data = await res.json();
+        const segments = JSON.parse(data.transcript);
+        transcriptText = segments.map((s: { text: string }) => s.text).join(" ");
+      } catch {
+        onToast?.("Failed to load transcript");
+        return;
+      }
+
+      const prompt = buildSummarizePrompt(videoTitle, transcriptText);
+
+      if (provider.urlTemplate && !provider.clipboardFallback) {
+        const encoded = encodeURIComponent(prompt);
+        // Truncate if URL would be excessively long (browsers cap around 2000-8000 chars)
+        const maxLen = 6000;
+        const url =
+          encoded.length > maxLen
+            ? provider.urlTemplate.replace("{prompt}", encoded.slice(0, maxLen))
+            : provider.urlTemplate.replace("{prompt}", encoded);
+        window.open(url, "_blank", "noopener,noreferrer");
+      } else {
+        // Clipboard fallback — copy prompt then open the provider
+        try {
+          await navigator.clipboard.writeText(prompt);
+          onToast?.("Prompt copied — paste into " + provider.name + " (⌘V)");
+        } catch {
+          onToast?.("Failed to copy prompt");
+        }
+        const fallbackUrl = OPEN_URLS[provider.id];
+        if (fallbackUrl) {
+          window.open(fallbackUrl, "_blank", "noopener,noreferrer");
+        }
+      }
+    },
+    [videoId, videoTitle, onToast]
+  );
+
+  // Sort providers so the last-used one appears first
+  const sortedProviders = lastProvider
+    ? [
+        ...PROVIDERS.filter((p) => p.id === lastProvider),
+        ...PROVIDERS.filter((p) => p.id !== lastProvider),
+      ]
+    : PROVIDERS;
+
+  return (
+    <div ref={dropdownRef} className="relative">
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          setOpen((prev) => !prev);
+        }}
+        title="Summarize with LLM..."
+        className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-white/60 transition hover:bg-white/5 hover:text-white/90 active:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/20"
+      >
+        {/* Sparkle / wand icon */}
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 20 20"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M10 2v2M10 16v2M2 10h2M16 10h2" />
+          <path d="M4.93 4.93l1.41 1.41M13.66 13.66l1.41 1.41M4.93 15.07l1.41-1.41M13.66 6.34l1.41-1.41" />
+          <circle cx="10" cy="10" r="2" />
+        </svg>
+      </button>
+
+      {open && (
+        <div
+          className="absolute right-0 top-full z-50 mt-1 min-w-[180px] overflow-hidden rounded-lg border border-white/15 bg-[hsl(var(--panel))] shadow-[0_20px_60px_-15px_rgba(0,0,0,0.7)]"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div className="px-3 py-2">
+            <p className="text-[10px] font-medium uppercase tracking-widest text-white/40">
+              Summarize with
+            </p>
+          </div>
+          {sortedProviders.map((provider) => (
+            <button
+              key={provider.id}
+              type="button"
+              onClick={() => launchWithProvider(provider)}
+              className="flex w-full items-center gap-3 px-3 py-2.5 text-left text-sm text-white/75 transition hover:bg-white/5 hover:text-white"
+            >
+              <span className="flex h-5 w-5 items-center justify-center rounded bg-white/10 text-[10px] font-bold uppercase text-white/60">
+                {provider.name[0]}
+              </span>
+              <span>{provider.name}</span>
+              {provider.id === lastProvider && (
+                <span className="ml-auto text-[10px] text-white/30">last used</span>
+              )}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -114,6 +114,61 @@ Returns a `.md` file with the formatted transcript.
 
 ---
 
+### Summarize Transcript
+
+Summarize a transcript using an LLM provider. The API key is passed per-request and never stored.
+
+```
+POST /api/transcripts/{id}/summarize
+```
+
+**Request:**
+```json
+{
+  "provider": "openai",
+  "apiKey": "sk-...",
+  "model": "gpt-4o",
+  "prompt": "Optional custom prompt. Transcript is appended automatically.",
+  "format": "markdown"
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `provider` | Yes | `"openai"` or `"anthropic"` |
+| `apiKey` | Yes | Your API key for the chosen provider (never stored) |
+| `model` | No | Model override. Defaults to `gpt-4o` (OpenAI) or `claude-sonnet-4-5-20250929` (Anthropic) |
+| `prompt` | No | Custom prompt. If omitted, a default summarization prompt is used |
+| `format` | No | `"markdown"` (default), `"text"`, or `"bullets"` |
+
+**Response:**
+```json
+{
+  "summary": "## Key Points\n\n- Point one...\n- Point two...",
+  "model_used": "gpt-4o-2024-08-06",
+  "provider": "openai",
+  "format": "markdown",
+  "token_count": {
+    "prompt_tokens": 1250,
+    "completion_tokens": 340
+  },
+  "video": {
+    "id": "cm5abc123def",
+    "title": "Rick Astley - Never Gonna Give You Up",
+    "videoUrl": "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+  }
+}
+```
+
+| Status | Description |
+|--------|-------------|
+| 200 | Summary generated |
+| 400 | Invalid request (missing provider, apiKey, empty transcript) |
+| 404 | Transcript not found |
+| 502 | LLM provider returned an error |
+
+---
+
 ## Data Types
 
 ### Transcript Segment
@@ -179,6 +234,16 @@ curl -X DELETE 'http://127.0.0.1:19720/api/transcripts/cm5abc123def'
 
 # Download markdown
 curl 'http://127.0.0.1:19720/api/transcripts/cm5abc123def/download' -o transcript.md
+
+# Summarize with OpenAI
+curl -X POST 'http://127.0.0.1:19720/api/transcripts/cm5abc123def/summarize' \
+  -H 'Content-Type: application/json' \
+  -d '{"provider": "openai", "apiKey": "sk-...", "format": "bullets"}'
+
+# Summarize with Anthropic
+curl -X POST 'http://127.0.0.1:19720/api/transcripts/cm5abc123def/summarize' \
+  -H 'Content-Type: application/json' \
+  -d '{"provider": "anthropic", "apiKey": "sk-ant-...", "model": "claude-sonnet-4-5-20250929"}'
 ```
 
 ### JavaScript


### PR DESCRIPTION
- POST /api/transcripts/[id]/summarize endpoint that accepts user's own OpenAI or Anthropic API key per-request (never stored) and returns a structured summary with token counts
- LLM launcher dropdown on each transcript row with ChatGPT (URL prefill) and Claude (clipboard + paste) options, remembers last-used provider
- Toast notification for clipboard fallback UX
- API documentation updated with summarize endpoint, request/response schemas, and curl examples