### PR TITLE
Add hover-reveal Summarize (Claude/ChatGPT) to side panel (YTT-205)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - **Generic video support via yt-dlp** — Any URL from a yt-dlp-supported site (Twitch, Vimeo, TikTok, Twitter/X, Dailymotion, Reddit, Instagram, Facebook, Rumble, BiliBili, Odysee, Streamable, and ~1,800 more) now routes through a generic transcription pipeline. Detects platform via yt-dlp extractor, downloads audio, transcribes via the existing provider fallback chain.
 - **New `lib/generic-video.ts` module** — Fetches metadata via `yt-dlp --dump-json`, downloads audio, re-encodes large files for cloud upload limits, falls back to local Whisper.
 - **`transcribeAudioFileWithWhisper`** (`lib/whisper.ts`) — New public helper that runs local Whisper on an arbitrary audio file path (not just YouTube videoIds). Reused by Spotify and the generic video route.
+- **URL input accepts any video URL** — Home page validator loosened from a YouTube/Spotify-only regex to any `http(s)://` URL. Server-side `parseContentUrl` + the generic yt-dlp route handle detection and routing. Placeholder and error copy updated to reflect multi-platform support.
 
 ### Changed
 - **Spotify transcription** — Wired up local Whisper fallback (previously stubbed out). Large podcast episodes are re-encoded to 48kbps mono MP3 before cloud upload so they fit under the Groq/OpenAI 25MB Whisper limit.

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -55,10 +55,13 @@ interface DebugFilters {
 }
 
 function isSupportedUrl(url: string): boolean {
-  return (
-    /^https?:\/\/(www\.)?(youtube\.com|youtu\.be)\/.+/.test(url) ||
-    /^https?:\/\/open\.spotify\.com\/episode\/.+/.test(url)
-  );
+  try {
+    const parsed = new URL(url);
+    // Accept any http(s) URL — yt-dlp handles ~1,800 sites via the generic route.
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
 }
 
 function formatDate(iso: string): string {
@@ -851,7 +854,7 @@ function HomeInner() {
     }
 
     if (!isSupportedUrl(trimmed)) {
-      setError("Please enter a valid YouTube or Spotify podcast URL.");
+      setError("Please enter a valid video URL.");
       return;
     }
 
@@ -905,7 +908,7 @@ function HomeInner() {
                       if (error) setError(null);
                       if (duplicateHint) setDuplicateHint(null);
                     }}
-                    placeholder="Paste a YouTube or Spotify podcast URL..."
+                    placeholder="Paste a video URL (YouTube, Spotify, Twitch, Vimeo, TikTok…)..."
                     className="h-12 pr-10"
                   />
                   {url && (
@@ -1191,7 +1194,7 @@ function HomeInner() {
                         </svg>
                       </div>
                       <p className="text-sm text-white/35">Your transcripts will appear here</p>
-                      <p className="mt-1.5 text-xs text-white/18">Paste a YouTube or Spotify podcast URL above to get started</p>
+                      <p className="mt-1.5 text-xs text-white/18">Paste a video URL (YouTube, Spotify, Twitch, Vimeo, TikTok…) above to get started</p>
                     </>
                   )}
                 </div>

--- a/extension/background.js
+++ b/extension/background.js
@@ -278,6 +278,30 @@ async function getRecent() {
   return all.slice(0, 5);
 }
 
+async function getTranscript(id) {
+  const config = await getApiConfig();
+  const res = await fetch(`${config.baseUrl}/api/transcripts/${id}`, {
+    headers: config.headers,
+  });
+  if (!res.ok) throw new Error(await classifyError(res.status, {}));
+  return await res.json();
+}
+
+async function getPreferences() {
+  const config = await getApiConfig();
+  if (config.mode !== "cloud") return { summarizePrompt: null };
+  try {
+    const res = await fetch(`${config.baseUrl}/api/preferences`, {
+      headers: config.headers,
+      signal: AbortSignal.timeout(3000),
+    });
+    if (!res.ok) return { summarizePrompt: null };
+    return await res.json();
+  } catch {
+    return { summarizePrompt: null };
+  }
+}
+
 async function checkExisting(videoId) {
   const config = await getApiConfig();
   const res = await fetch(`${config.baseUrl}/api/transcripts`, {
@@ -390,6 +414,12 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
       case "GET_RECENT":
         return await getRecent();
+
+      case "GET_TRANSCRIPT":
+        return await getTranscript(message.id);
+
+      case "GET_PREFERENCES":
+        return await getPreferences();
 
       case "CHECK_EXISTING":
         return await checkExisting(message.videoId);

--- a/extension/background.js
+++ b/extension/background.js
@@ -9,25 +9,29 @@ let _apiConfigCache = null;
 
 async function getApiConfig() {
   if (_apiConfigCache) return _apiConfigCache;
-  const { mode, apiKey } = await chrome.storage.sync.get(["mode", "apiKey"]);
-  _apiConfigCache = buildConfig(mode || "cloud", apiKey || "");
+  const { mode } = await chrome.storage.sync.get(["mode"]);
+  _apiConfigCache = buildConfig(mode || "cloud");
   return _apiConfigCache;
 }
 
-function buildConfig(mode, apiKey) {
+function buildConfig(mode) {
   if (mode === "cloud") {
+    // Cloud auth rides on the user's transcribed.dev session cookie.
+    // `credentials: "include"` on fetch sends the cookie cross-origin;
+    // host_permissions for transcribed.dev allows it.
     return {
       mode: "cloud",
       baseUrl: CLOUD_BASE,
-      headers: apiKey ? { Authorization: `Bearer ${apiKey}` } : {},
+      headers: {},
+      credentials: "include",
     };
   }
-  return { mode: "local", baseUrl: LOCAL_BASE, headers: {} };
+  return { mode: "local", baseUrl: LOCAL_BASE, headers: {}, credentials: "omit" };
 }
 
 // Invalidate cache when settings change
 chrome.storage.onChanged.addListener((changes, area) => {
-  if (area === "sync" && (changes.mode || changes.apiKey)) {
+  if (area === "sync" && changes.mode) {
     _apiConfigCache = null;
   }
 });
@@ -151,23 +155,23 @@ function setBadge(text, color) {
 
 async function checkService() {
   const config = await getApiConfig();
-  const health = await tryHealthCheck(config.baseUrl, config.headers, config.mode);
+  const health = await tryHealthCheck(config.baseUrl, config.headers, config.mode, config.credentials);
 
-  // In cloud mode, the health endpoint doesn't require auth — so a 200 from
-  // /api/health doesn't mean the API key is valid. Validate the key separately
-  // by hitting an authenticated endpoint.
-  if (health.online && config.mode === "cloud" && config.headers.Authorization) {
+  // In cloud mode, /api/health doesn't require auth — so a 200 from it
+  // doesn't mean the user is signed in. Validate the session separately
+  // by hitting an authenticated endpoint with the cookie.
+  if (health.online && config.mode === "cloud") {
     try {
       const res = await fetch(`${config.baseUrl}/api/account`, {
         method: "GET",
-        headers: config.headers,
+        credentials: config.credentials,
         signal: AbortSignal.timeout(3000),
       });
       if (res.status === 401) {
         return { online: false, mode: "cloud", authError: true };
       }
     } catch {
-      // Network error on key check — still treat as online since health passed
+      // Network error on session check — still treat as online since health passed
     }
   }
 
@@ -187,11 +191,12 @@ async function detectLocalInstance() {
   }
 }
 
-async function tryHealthCheck(baseUrl, headers, mode) {
+async function tryHealthCheck(baseUrl, headers, mode, credentials) {
   try {
     const res = await fetch(`${baseUrl}/api/health`, {
       method: "GET",
       headers,
+      credentials: credentials || "omit",
       signal: AbortSignal.timeout(3000),
     });
     if (res.ok) {
@@ -212,6 +217,7 @@ async function transcribeRequest(url) {
   const res = await fetch(`${config.baseUrl}/api/transcripts`, {
     method: "POST",
     headers: { "Content-Type": "application/json", ...config.headers },
+    credentials: config.credentials,
     body: JSON.stringify({ url }),
   });
   const data = await res.json();
@@ -234,6 +240,7 @@ async function pollUntilDone(id, config) {
     try {
       const res = await fetch(`${config.baseUrl}/api/transcripts/${id}`, {
         headers: config.headers,
+        credentials: config.credentials,
       });
       if (!res.ok) continue;
       const data = await res.json();
@@ -262,7 +269,7 @@ async function classifyError(status, data) {
     if (status >= 500) return "Local server error. Check the terminal for details.";
     return data?.error || `HTTP ${status}`;
   }
-  if (status === 401) return "Invalid API key. Check your key in Settings or at transcribed.dev/developers";
+  if (status === 401) return "Sign in at transcribed.dev to continue.";
   if (status === 429) return "Quota reached. Upgrade your plan at transcribed.dev/pricing";
   if (status >= 500) return "Cloud service error. Try again in a moment.";
   return data?.error || `HTTP ${status}`;
@@ -272,6 +279,7 @@ async function getRecent() {
   const config = await getApiConfig();
   const res = await fetch(`${config.baseUrl}/api/transcripts`, {
     headers: config.headers,
+    credentials: config.credentials,
   });
   if (!res.ok) throw new Error(await classifyError(res.status, {}));
   const all = await res.json();
@@ -282,6 +290,7 @@ async function getTranscript(id) {
   const config = await getApiConfig();
   const res = await fetch(`${config.baseUrl}/api/transcripts/${id}`, {
     headers: config.headers,
+    credentials: config.credentials,
   });
   if (!res.ok) throw new Error(await classifyError(res.status, {}));
   return await res.json();
@@ -293,6 +302,7 @@ async function getPreferences() {
   try {
     const res = await fetch(`${config.baseUrl}/api/preferences`, {
       headers: config.headers,
+      credentials: config.credentials,
       signal: AbortSignal.timeout(3000),
     });
     if (!res.ok) return { summarizePrompt: null };
@@ -306,6 +316,7 @@ async function checkExisting(videoId) {
   const config = await getApiConfig();
   const res = await fetch(`${config.baseUrl}/api/transcripts`, {
     headers: config.headers,
+    credentials: config.credentials,
   });
   if (!res.ok) return null;
   const all = await res.json();
@@ -481,8 +492,8 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         return { ok: true };
 
       case "GET_SETTINGS": {
-        const { mode, apiKey } = await chrome.storage.sync.get(["mode", "apiKey"]);
-        return { mode: mode || "cloud", hasApiKey: !!apiKey };
+        const { mode } = await chrome.storage.sync.get(["mode"]);
+        return { mode: mode || "cloud" };
       }
 
       case "DETECT_LOCAL": {
@@ -493,15 +504,9 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       case "SAVE_SETTINGS": {
         const settings = {};
         if (message.mode !== undefined) settings.mode = message.mode;
-        if (message.apiKey !== undefined) settings.apiKey = message.apiKey;
         await chrome.storage.sync.set(settings);
         _apiConfigCache = null;
         return { ok: true };
-      }
-
-      case "TEST_CONNECTION": {
-        const testConfig = buildConfig(message.mode, message.apiKey);
-        return await tryHealthCheck(testConfig.baseUrl, testConfig.headers, message.mode);
       }
 
       case "GET_PAGE_INFO": {

--- a/extension/background.js
+++ b/extension/background.js
@@ -168,7 +168,22 @@ async function checkService() {
         signal: AbortSignal.timeout(3000),
       });
       if (res.status === 401) {
-        return { online: false, mode: "cloud", authError: true };
+        // Distinguish first-time users (never signed in on this install)
+        // from returning users whose session expired, so the UI can pick
+        // "Get started" vs "Signed out" copy.
+        const { hasEverSignedIn } = await chrome.storage.local.get(
+          "hasEverSignedIn"
+        );
+        return {
+          online: false,
+          mode: "cloud",
+          authError: true,
+          firstTime: !hasEverSignedIn,
+        };
+      }
+      if (res.ok) {
+        // Remember that this install has authed at least once.
+        await chrome.storage.local.set({ hasEverSignedIn: true });
       }
     } catch {
       // Network error on session check — still treat as online since health passed
@@ -386,10 +401,56 @@ async function processNextInQueue() {
 }
 
 // ---------------------------------------------------------------------------
+// Message payload validation
+// Content scripts run in pages we don't control (YouTube / Spotify DOM),
+// so every string that crosses the background boundary gets type- and
+// shape-checked. Popup messages are validated the same way for defense
+// in depth and consistent error surfaces.
+// ---------------------------------------------------------------------------
+
+const MAX_URL_LEN = 2048;
+const MAX_TITLE_LEN = 512;
+const ID_MAX_LEN = 128;
+const ID_PATTERN = /^[A-Za-z0-9_-]+$/;
+
+function isStr(v, maxLen) {
+  return typeof v === "string" && v.length > 0 && v.length <= maxLen;
+}
+
+function validHttpUrl(u) {
+  if (!isStr(u, MAX_URL_LEN)) return false;
+  try {
+    const parsed = new URL(u);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function clampTitle(t) {
+  if (typeof t !== "string") return "";
+  return t.length > MAX_TITLE_LEN ? t.slice(0, MAX_TITLE_LEN) : t;
+}
+
+function validId(id) {
+  return isStr(id, ID_MAX_LEN) && ID_PATTERN.test(id);
+}
+
+function validMode(m) {
+  return m === "cloud" || m === "local";
+}
+
+// ---------------------------------------------------------------------------
 // Message handler
 // ---------------------------------------------------------------------------
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  // Reject anything not shaped like { type: string }
+  if (!message || typeof message.type !== "string") {
+    sendResponse({ success: false, error: "Invalid message" });
+    return false;
+  }
+
   const handle = async () => {
     switch (message.type) {
       case "CLOSE_PANEL": {
@@ -412,8 +473,12 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       case "CHECK_SERVICE":
         return await checkService();
 
-      case "TRANSCRIBE":
-        return await doTranscribe(message.url, message.title);
+      case "TRANSCRIBE": {
+        if (!validHttpUrl(message.url)) {
+          throw new Error("Invalid url");
+        }
+        return await doTranscribe(message.url, clampTitle(message.title));
+      }
 
       case "GET_TRANSCRIPTION_STATUS":
         return await getState();
@@ -426,20 +491,27 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       case "GET_RECENT":
         return await getRecent();
 
-      case "GET_TRANSCRIPT":
+      case "GET_TRANSCRIPT": {
+        if (!validId(message.id)) throw new Error("Invalid id");
         return await getTranscript(message.id);
+      }
 
       case "GET_PREFERENCES":
         return await getPreferences();
 
-      case "CHECK_EXISTING":
+      case "CHECK_EXISTING": {
+        if (!validId(message.videoId)) throw new Error("Invalid videoId");
         return await checkExisting(message.videoId);
+      }
 
       case "QUEUE_ADD": {
+        if (!validHttpUrl(message.url)) {
+          throw new Error("Invalid url");
+        }
         const queue = await getQueue();
         const already = queue.some((q) => q.url === message.url);
         if (!already) {
-          queue.push({ url: message.url, title: message.title || "" });
+          queue.push({ url: message.url, title: clampTitle(message.title) });
           await setQueue(queue);
         }
         return { ok: true, queue };
@@ -456,11 +528,12 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         return await processNextInQueue();
 
       case "OPEN_TRANSCRIPT": {
+        if (!validId(message.id)) throw new Error("Invalid id");
         const transcriptId = message.id;
         const config = await getApiConfig();
         const appBase = config.mode === "cloud" ? CLOUD_BASE : LOCAL_BASE;
         // Append timestamp to bust Chrome's same-URL no-op optimization
-        const fullUrl = `${appBase}/?layout=list&id=${transcriptId}&t=${Date.now()}`;
+        const fullUrl = `${appBase}/?layout=list&id=${encodeURIComponent(transcriptId)}&t=${Date.now()}`;
 
         // Find existing app tab
         const matchHost = config.mode === "cloud" ? "www.transcribed.dev" : "localhost:19720";
@@ -478,18 +551,24 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       }
 
       case "PAGE_INFO":
-      case "PAGE_CHANGED":
-        if (sender.tab?.id) {
-          await chrome.storage.session.set({
-            [`tab_${sender.tab.id}`]: {
-              url: message.url,
-              title: message.title,
-              videoId: message.videoId,
-              isLive: !!message.isLive,
-            },
-          });
-        }
+      case "PAGE_CHANGED": {
+        // Content scripts run in untrusted YouTube/Spotify DOM — validate
+        // every string before persisting. Silently drop malformed payloads
+        // instead of erroring so a hostile page can't spam the console.
+        if (!sender.tab?.id) return { ok: true };
+        if (!validHttpUrl(message.url)) return { ok: true };
+        const vid = typeof message.videoId === "string" ? message.videoId : null;
+        if (vid !== null && !validId(vid)) return { ok: true };
+        await chrome.storage.session.set({
+          [`tab_${sender.tab.id}`]: {
+            url: message.url,
+            title: clampTitle(message.title),
+            videoId: vid,
+            isLive: !!message.isLive,
+          },
+        });
         return { ok: true };
+      }
 
       case "GET_SETTINGS": {
         const { mode } = await chrome.storage.sync.get(["mode"]);
@@ -503,7 +582,10 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
       case "SAVE_SETTINGS": {
         const settings = {};
-        if (message.mode !== undefined) settings.mode = message.mode;
+        if (message.mode !== undefined) {
+          if (!validMode(message.mode)) throw new Error("Invalid mode");
+          settings.mode = message.mode;
+        }
         await chrome.storage.sync.set(settings);
         _apiConfigCache = null;
         return { ok: true };

--- a/extension/build.js
+++ b/extension/build.js
@@ -23,6 +23,8 @@ const COPY_FILES = [
   "popup.html",
   "popup.js",
   "popup.css",
+  "popup-shell.html",
+  "popup-shell.js",
   "setup-link.css",
   "content.js",
   "content-spotify.js",

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "YouTube Transcriber",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "One-click transcription for YouTube videos and Spotify podcasts. Works with transcribed.dev or your own self-hosted instance.",
   "permissions": [
     "activeTab",

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,8 +1,11 @@
 {
   "manifest_version": 3,
   "name": "YouTube Transcriber",
-  "version": "1.5.0",
-  "description": "One-click transcription for YouTube videos and Spotify podcasts. Works with transcribed.dev or your own self-hosted instance.",
+  "version": "1.5.1",
+  "description": "One-click transcription for videos and podcasts. Works with transcribed.dev or your own self-hosted instance.",
+  "content_security_policy": {
+    "extension_pages": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' http://localhost:19720 http://127.0.0.1:19720 https://transcribed.dev https://www.transcribed.dev; frame-src https://transcribed.dev https://www.transcribed.dev; object-src 'none'; base-uri 'none'; form-action 'none'"
+  },
   "permissions": [
     "activeTab",
     "tabs",

--- a/extension/popup-shell.html
+++ b/extension/popup-shell.html
@@ -51,58 +51,6 @@
     <a href="#" id="btnRetryLoad">Try again</a>
   </div>
 
-  <script>
-    const port = chrome.runtime.connect({ name: "sidepanel" });
-
-    port.onMessage.addListener((msg) => {
-      if (msg.type === "CLOSE") window.close();
-    });
-
-    const frame = document.getElementById("appFrame");
-    const error = document.getElementById("shellError");
-
-    // Show error state if iframe fails to load
-    let loaded = false;
-    frame.addEventListener("load", () => { loaded = true; });
-
-    setTimeout(() => {
-      if (!loaded) {
-        frame.style.display = "none";
-        error.style.display = "flex";
-      }
-    }, 8000);
-
-    document.getElementById("btnRetryLoad").addEventListener("click", (e) => {
-      e.preventDefault();
-      error.style.display = "none";
-      frame.style.display = "block";
-      frame.src = frame.src;
-      loaded = false;
-      setTimeout(() => {
-        if (!loaded) {
-          frame.style.display = "none";
-          error.style.display = "flex";
-        }
-      }, 8000);
-    });
-
-    // Forward messages between iframe and background.
-    // Strict origin check — only accept frames from transcribed.dev, and
-    // post responses back to the same origin (no "*" wildcards).
-    const ALLOWED_ORIGIN = "https://transcribed.dev";
-    window.addEventListener("message", (event) => {
-      if (event.origin !== ALLOWED_ORIGIN) return;
-      if (event.source !== frame.contentWindow) return;
-      if (!event.data || typeof event.data.type !== "string") return;
-      const requestId = event.data._requestId;
-      chrome.runtime.sendMessage(event.data, (response) => {
-        if (!frame.contentWindow) return;
-        frame.contentWindow.postMessage(
-          { _responseId: requestId, ...response },
-          ALLOWED_ORIGIN
-        );
-      });
-    });
-  </script>
+  <script src="popup-shell.js"></script>
 </body>
 </html>

--- a/extension/popup-shell.html
+++ b/extension/popup-shell.html
@@ -39,7 +39,12 @@
   </style>
 </head>
 <body>
-  <iframe id="appFrame" src="https://transcribed.dev/extension"></iframe>
+  <iframe
+    id="appFrame"
+    src="https://transcribed.dev/extension"
+    sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox"
+    allow="clipboard-write"
+  ></iframe>
 
   <div class="shell-error" id="shellError">
     <p>Couldn't load the panel</p>
@@ -81,17 +86,22 @@
       }, 8000);
     });
 
-    // Forward messages between iframe and background
+    // Forward messages between iframe and background.
+    // Strict origin check — only accept frames from transcribed.dev, and
+    // post responses back to the same origin (no "*" wildcards).
+    const ALLOWED_ORIGIN = "https://transcribed.dev";
     window.addEventListener("message", (event) => {
+      if (event.origin !== ALLOWED_ORIGIN) return;
       if (event.source !== frame.contentWindow) return;
-      if (event.data?.type) {
-        chrome.runtime.sendMessage(event.data, (response) => {
-          frame.contentWindow.postMessage(
-            { _responseId: event.data._requestId, ...response },
-            "*"
-          );
-        });
-      }
+      if (!event.data || typeof event.data.type !== "string") return;
+      const requestId = event.data._requestId;
+      chrome.runtime.sendMessage(event.data, (response) => {
+        if (!frame.contentWindow) return;
+        frame.contentWindow.postMessage(
+          { _responseId: requestId, ...response },
+          ALLOWED_ORIGIN
+        );
+      });
     });
   </script>
 </body>

--- a/extension/popup-shell.js
+++ b/extension/popup-shell.js
@@ -1,0 +1,51 @@
+const port = chrome.runtime.connect({ name: "sidepanel" });
+
+port.onMessage.addListener((msg) => {
+  if (msg.type === "CLOSE") window.close();
+});
+
+const frame = document.getElementById("appFrame");
+const error = document.getElementById("shellError");
+
+// Show error state if iframe fails to load
+let loaded = false;
+frame.addEventListener("load", () => { loaded = true; });
+
+setTimeout(() => {
+  if (!loaded) {
+    frame.style.display = "none";
+    error.style.display = "flex";
+  }
+}, 8000);
+
+document.getElementById("btnRetryLoad").addEventListener("click", (e) => {
+  e.preventDefault();
+  error.style.display = "none";
+  frame.style.display = "block";
+  frame.src = frame.src;
+  loaded = false;
+  setTimeout(() => {
+    if (!loaded) {
+      frame.style.display = "none";
+      error.style.display = "flex";
+    }
+  }, 8000);
+});
+
+// Forward messages between iframe and background.
+// Strict origin check — only accept frames from transcribed.dev, and
+// post responses back to the same origin (no "*" wildcards).
+const ALLOWED_ORIGIN = "https://transcribed.dev";
+window.addEventListener("message", (event) => {
+  if (event.origin !== ALLOWED_ORIGIN) return;
+  if (event.source !== frame.contentWindow) return;
+  if (!event.data || typeof event.data.type !== "string") return;
+  const requestId = event.data._requestId;
+  chrome.runtime.sendMessage(event.data, (response) => {
+    if (!frame.contentWindow) return;
+    frame.contentWindow.postMessage(
+      { _responseId: requestId, ...response },
+      ALLOWED_ORIGIN
+    );
+  });
+});

--- a/extension/popup.css
+++ b/extension/popup.css
@@ -870,56 +870,43 @@ body::-webkit-scrollbar-thumb:hover {
   border-color: var(--border-hover);
 }
 
-/* Onboarding steps */
-.onboarding-steps {
-  display: flex;
-  flex-direction: column;
-  gap: 0;
-  width: 100%;
-  max-width: 260px;
-  margin-bottom: 12px;
-}
-.onboarding-step {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 10px 0;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
-}
-.onboarding-step:last-child {
-  border-bottom: none;
-}
-.onboarding-step-num {
-  flex-shrink: 0;
-  width: 20px;
-  height: 20px;
-  border-radius: 50%;
-  background: rgba(255, 255, 255, 0.06);
-  color: var(--muted-3);
-  font-size: 11px;
-  font-weight: 600;
-  display: flex;
+/* Cloud sign-in CTA — shown in cloud onboarding + auth-error states */
+.btn-cloud-signin {
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-}
-.onboarding-step-text {
-  flex: 1;
-  font-size: 12px;
-  color: var(--muted-2);
-}
-.onboarding-step-action {
-  flex-shrink: 0;
-  border: none;
-  background: none;
-  color: var(--accent);
-  font-size: 11px;
+  margin-top: 4px;
+  padding: 8px 18px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text);
+  font-size: 13px;
   font-weight: 500;
-  cursor: pointer;
-  padding: 0;
+  text-decoration: none;
+  transition: background 0.15s, border-color 0.15s;
+}
+.btn-cloud-signin:hover {
+  background: rgba(255, 255, 255, 0.16);
+  border-color: var(--border-hover);
+}
+
+/* Cloud account link in settings */
+.settings-account {
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+}
+.settings-account[hidden] {
+  display: none;
+}
+.settings-account-link {
+  font-size: 12px;
+  color: var(--accent);
   text-decoration: none;
   transition: opacity 0.15s;
 }
-.onboarding-step-action:hover {
+.settings-account-link:hover {
   opacity: 0.8;
 }
 

--- a/extension/popup.css
+++ b/extension/popup.css
@@ -486,6 +486,7 @@ body::-webkit-scrollbar-thumb:hover {
   background: rgba(255, 255, 255, 0.15);
 }
 .recent-item {
+  position: relative;
   display: flex;
   align-items: center;
   gap: 8px;
@@ -496,6 +497,122 @@ body::-webkit-scrollbar-thumb:hover {
 }
 .recent-item:hover {
   background: rgba(255, 255, 255, 0.05);
+}
+
+/* Summarize-with-LLM — hover-reveal, mirrors web-app LlmLauncher */
+.recent-summarize {
+  position: relative;
+  margin-left: 6px;
+  flex-shrink: 0;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+.recent-item:hover .recent-summarize,
+.recent-summarize:focus-within {
+  opacity: 1;
+}
+.recent-summarize-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.55);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, transform 0.3s;
+}
+.recent-summarize-btn:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.9);
+}
+.recent-summarize-btn:hover svg {
+  transform: rotate(15deg);
+}
+.recent-summarize-btn svg {
+  transition: transform 0.3s;
+}
+.recent-summarize-btn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.18);
+}
+
+.recent-summarize-menu {
+  position: fixed;
+  z-index: 9999;
+  min-width: 180px;
+  padding: 4px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  background: var(--panel);
+  box-shadow: 0 20px 60px -15px rgba(0, 0, 0, 0.7);
+}
+.recent-summarize-menu-label {
+  padding: 6px 8px 4px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted-3);
+}
+.recent-summarize-menu-item {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 10px 12px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.75);
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+}
+.recent-summarize-menu-item:hover {
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--text);
+}
+.recent-summarize-menu-name {
+  flex: 1;
+}
+.recent-summarize-icon {
+  flex-shrink: 0;
+}
+.recent-summarize-menu-hint {
+  font-size: 10px;
+  color: rgba(255, 255, 255, 0.3);
+}
+
+/* Clipboard-hint tooltip — mirrors the web-app LlmLauncher delay/fade */
+.recent-summarize-menu-tip {
+  pointer-events: none;
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  margin-bottom: 6px;
+  transform: translateX(calc(-50% + 10px));
+  padding: 6px 10px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 6px;
+  background: var(--panel);
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 11px;
+  white-space: nowrap;
+  opacity: 0;
+  transition: opacity 0.2s;
+  box-shadow: 0 8px 20px -8px rgba(0, 0, 0, 0.7);
+}
+.recent-summarize-menu-item:hover .recent-summarize-menu-tip {
+  opacity: 1;
+  transition-delay: 0.4s;
+}
+.recent-summarize-menu-tip-key {
+  color: rgba(255, 255, 255, 0.7);
 }
 .recent-item-content {
   display: flex;

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -76,7 +76,7 @@
     <!-- Not a supported page -->
     <div id="stateNotYoutube" class="state" hidden>
       <p class="message">Navigate to a video or podcast</p>
-      <p class="submessage">Open a YouTube video or Spotify episode to transcribe it</p>
+      <p class="submessage">Open a supported video or podcast to transcribe it</p>
     </div>
 
     <!-- Ready (not yet transcribed, or already transcribed) -->

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -35,34 +35,21 @@
 
       <!-- Cloud mode offline / onboarding -->
       <div id="offlineCloudMsg" hidden>
-        <!-- Shown when user has no API key (first-time onboarding) -->
+        <!-- Shown when user has no session (first-time onboarding) -->
         <div id="cloudOnboarding">
           <p class="offline-heading">Get started</p>
           <p class="offline-sub">Transcribe 10 videos/month for free</p>
-
-          <div class="onboarding-steps">
-            <div class="onboarding-step">
-              <span class="onboarding-step-num">1</span>
-              <span class="onboarding-step-text">Create a free account</span>
-              <a class="onboarding-step-action" href="https://www.transcribed.dev/auth/signup" target="_blank">Sign up →</a>
-            </div>
-            <div class="onboarding-step">
-              <span class="onboarding-step-num">2</span>
-              <span class="onboarding-step-text">Copy your API key</span>
-              <a class="onboarding-step-action" href="https://www.transcribed.dev/developers#keys" target="_blank">Get key →</a>
-            </div>
-            <div class="onboarding-step">
-              <span class="onboarding-step-num">3</span>
-              <span class="onboarding-step-text">Paste it here</span>
-              <button class="onboarding-step-action" id="btnHaveAccount">Enter key →</button>
-            </div>
-          </div>
+          <a class="btn-cloud-signin" href="https://www.transcribed.dev/auth/signin" target="_blank">
+            Sign in at transcribed.dev →
+          </a>
         </div>
-        <!-- Shown when user has an API key but it's failing -->
+        <!-- Shown when the session has expired -->
         <div id="cloudAuthError" hidden>
-          <p class="offline-heading">Can't reach cloud</p>
-          <p class="offline-sub" id="offlineCloudSub">Check your API key or try again later</p>
-          <a class="settings-help-link" href="https://www.transcribed.dev/developers#keys" target="_blank" style="margin-top: 4px; display: inline-block;">Manage API key →</a>
+          <p class="offline-heading">Signed out</p>
+          <p class="offline-sub">Your session expired — sign in again to continue.</p>
+          <a class="btn-cloud-signin" href="https://www.transcribed.dev/auth/signin" target="_blank">
+            Sign in again →
+          </a>
         </div>
       </div>
 
@@ -161,17 +148,10 @@
           <button class="settings-mode-btn" id="btnModeLocal" data-mode="local">Self-hosted</button>
         </div>
       </div>
-      <div id="apiKeySection" class="settings-api-key" hidden>
-        <label class="settings-label" for="apiKeyInput">API Key</label>
-        <div class="settings-input-row">
-          <input type="password" id="apiKeyInput" class="settings-input" placeholder="ytt_sk_..." autocomplete="off" spellcheck="false" />
-          <button class="settings-test-btn" id="btnTestConnection">Test</button>
-        </div>
-        <div id="connectionStatus" class="settings-status" hidden></div>
-        <div class="settings-api-key-footer">
-          <a class="settings-help-link" href="https://www.transcribed.dev/developers#keys" target="_blank">Get an API key →</a>
-          <button class="btn-settings-save" id="btnSaveSettings">Save key</button>
-        </div>
+      <div id="cloudAccountSection" class="settings-account" hidden>
+        <a class="settings-account-link" href="https://www.transcribed.dev/account" target="_blank">
+          Manage account at transcribed.dev →
+        </a>
       </div>
     </div>
 

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -35,10 +35,8 @@ const el = {
   offlineCommand: document.getElementById("offlineCommand"),
   offlineLocalMsg: document.getElementById("offlineLocalMsg"),
   offlineCloudMsg: document.getElementById("offlineCloudMsg"),
-  offlineCloudSub: document.getElementById("offlineCloudSub"),
   cloudOnboarding: document.getElementById("cloudOnboarding"),
   cloudAuthError: document.getElementById("cloudAuthError"),
-  btnHaveAccount: document.getElementById("btnHaveAccount"),
   localDetectedBanner: document.getElementById("localDetectedBanner"),
   btnUseLocal: document.getElementById("btnUseLocal"),
   cloudNudge: document.getElementById("cloudNudge"),
@@ -48,11 +46,7 @@ const el = {
   settingsPanel: document.getElementById("settingsPanel"),
   btnModeLocal: document.getElementById("btnModeLocal"),
   btnModeCloud: document.getElementById("btnModeCloud"),
-  apiKeySection: document.getElementById("apiKeySection"),
-  apiKeyInput: document.getElementById("apiKeyInput"),
-  btnTestConnection: document.getElementById("btnTestConnection"),
-  connectionStatus: document.getElementById("connectionStatus"),
-  btnSaveSettings: document.getElementById("btnSaveSettings"),
+  cloudAccountSection: document.getElementById("cloudAccountSection"),
 };
 
 let pageInfo = null;
@@ -784,7 +778,6 @@ async function init() {
     const cfgRes = await sendMsg({ type: "GET_SETTINGS" });
     if (thisInit !== initVersion) return;
     const cfgMode = cfgRes?.data?.mode || "cloud";
-    const hasApiKey = cfgRes?.data?.hasApiKey;
     const authError = serviceRes?.data?.authError;
 
     if (cfgMode === "cloud") {
@@ -793,17 +786,12 @@ async function init() {
       el.cloudNudge.hidden = true;
       el.localDetectedBanner.hidden = true;
 
-      if (hasApiKey) {
-        // Has a key but it's failing — show error state
+      if (authError) {
+        // Session expired or not signed in
         el.cloudOnboarding.hidden = true;
         el.cloudAuthError.hidden = false;
-        if (authError) {
-          el.offlineCloudSub.textContent = "Your API key is invalid. Update it in settings.";
-        } else {
-          el.offlineCloudSub.textContent = "Check your API key or try again later";
-        }
       } else {
-        // No key — show onboarding
+        // Service reachable but not signed in — first-time onboarding
         el.cloudOnboarding.hidden = false;
         el.cloudAuthError.hidden = true;
       }
@@ -827,28 +815,6 @@ async function init() {
     return;
   }
   stopOfflinePolling();
-
-  // Cloud mode without API key — show onboarding instead of Transcribe button
-  const cfgCheck = await sendMsg({ type: "GET_SETTINGS" });
-  if (thisInit !== initVersion) return;
-  if (cfgCheck?.data?.mode === "cloud" && !cfgCheck?.data?.hasApiKey) {
-    el.offlineLocalMsg.hidden = true;
-    el.offlineCloudMsg.hidden = false;
-    el.cloudNudge.hidden = true;
-    el.localDetectedBanner.hidden = true;
-    el.cloudOnboarding.hidden = false;
-    el.cloudAuthError.hidden = true;
-
-    // Auto-detect local instance and show banner
-    const localRes = await sendMsg({ type: "DETECT_LOCAL" });
-    if (thisInit !== initVersion) return;
-    if (localRes?.success && localRes.data?.available) {
-      el.localDetectedBanner.hidden = false;
-    }
-
-    showState("NoService");
-    return;
-  }
 
   startHeartbeat();
 
@@ -995,11 +961,6 @@ el.btnTranscribe.addEventListener("click", doTranscribe);
 el.btnRetry.addEventListener("click", doTranscribe);
 el.btnCheckAgain.addEventListener("click", init);
 
-// "Already have an API key?" — jump to settings with cloud mode
-el.btnHaveAccount.addEventListener("click", () => {
-  showSettingsView();
-});
-
 // "Switch to self-hosted" — auto-switch to local mode
 el.btnUseLocal.addEventListener("click", async () => {
   await sendMsg({ type: "SAVE_SETTINGS", mode: "local" });
@@ -1134,78 +1095,25 @@ el.btnNavLibrary.addEventListener("click", () => {
 async function loadSettings() {
   const res = await sendMsg({ type: "GET_SETTINGS" });
   if (!res?.success) return;
-  const { mode, hasApiKey } = res.data;
+  const { mode } = res.data;
   setModeUI(mode);
-  el.connectionStatus.hidden = true;
-  if (hasApiKey) {
-    el.apiKeyInput.value = "\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022";
-    el.apiKeyInput.dataset.unchanged = "true";
-  } else {
-    el.apiKeyInput.value = "";
-    delete el.apiKeyInput.dataset.unchanged;
-  }
 }
 
 function setModeUI(mode) {
   currentSettingsMode = mode;
   el.btnModeLocal.classList.toggle("active", mode === "local");
   el.btnModeCloud.classList.toggle("active", mode === "cloud");
-  el.apiKeySection.hidden = mode !== "cloud";
+  el.cloudAccountSection.hidden = mode !== "cloud";
 }
 
 el.btnModeLocal.addEventListener("click", async () => {
   setModeUI("local");
   await sendMsg({ type: "SAVE_SETTINGS", mode: "local" });
+  init();
 });
 el.btnModeCloud.addEventListener("click", async () => {
   setModeUI("cloud");
   await sendMsg({ type: "SAVE_SETTINGS", mode: "cloud" });
-});
-
-el.apiKeyInput.addEventListener("focus", () => {
-  if (el.apiKeyInput.dataset.unchanged === "true") {
-    el.apiKeyInput.value = "";
-    delete el.apiKeyInput.dataset.unchanged;
-  }
-});
-
-el.btnTestConnection.addEventListener("click", async () => {
-  el.connectionStatus.hidden = false;
-  el.connectionStatus.textContent = "Testing...";
-  el.connectionStatus.className = "settings-status testing";
-
-  // Use the entered key, or fetch the stored one if unchanged
-  let apiKey;
-  if (el.apiKeyInput.dataset.unchanged === "true") {
-    const stored = await chrome.storage.sync.get("apiKey");
-    apiKey = stored.apiKey || "";
-  } else {
-    apiKey = el.apiKeyInput.value;
-  }
-
-  const res = await sendMsg({
-    type: "TEST_CONNECTION",
-    mode: currentSettingsMode,
-    apiKey,
-  });
-
-  if (res?.success && res.data?.online) {
-    el.connectionStatus.textContent = "Connected";
-    el.connectionStatus.className = "settings-status success";
-  } else if (res?.data?.authError) {
-    el.connectionStatus.textContent = "Invalid API key";
-    el.connectionStatus.className = "settings-status error";
-  } else {
-    el.connectionStatus.textContent = "Connection failed";
-    el.connectionStatus.className = "settings-status error";
-  }
-});
-
-el.btnSaveSettings.addEventListener("click", async () => {
-  if (el.apiKeyInput.dataset.unchanged === "true") return;
-  await sendMsg({ type: "SAVE_SETTINGS", apiKey: el.apiKeyInput.value });
-  el.apiKeyInput.dataset.unchanged = "true";
-  el.apiKeyInput.value = "\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022";
   init();
 });
 

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -125,6 +125,274 @@ function startIndeterminate() {
 }
 
 // ---------------------------------------------------------------------------
+// LLM launcher — mirrors components/ui/llm-launcher.tsx from the web app.
+// Hover-reveal sparkle button per recent row; opens a small dropdown to
+// summarize the transcript with Claude or ChatGPT. The extension never
+// renders transcript content — it only fetches, builds a prompt, and
+// hands off to the provider surface.
+// ---------------------------------------------------------------------------
+
+const LLM_STORAGE_KEY = "llm-launcher-last-provider";
+const LLM_DEFAULT_PROMPT =
+  'Summarize the following transcript from "{title}". Focus on the main topics, key insights, and any actionable takeaways.';
+
+const LLM_ICONS = {
+  claude: `
+    <svg class="recent-summarize-icon" width="14" height="14" viewBox="0 0 100 100" fill="#D97757" aria-hidden="true">
+      <path d="m19.6 66.5 19.7-11 .3-1-.3-.5h-1l-3.3-.2-11.2-.3L14 53l-9.5-.5-2.4-.5L0 49l.2-1.5 2-1.3 2.9.2 6.3.5 9.5.6 6.9.4L38 49.1h1.6l.2-.7-.5-.4-.4-.4L29 41l-10.6-7-5.6-4.1-3-2-1.5-2-.6-4.2 2.7-3 3.7.3.9.2 3.7 2.9 8 6.1L37 36l1.5 1.2.6-.4.1-.3-.7-1.1L33 25l-6-10.4-2.7-4.3-.7-2.6c-.3-1-.4-2-.4-3l3-4.2L28 0l4.2.6L33.8 2l2.6 6 4.1 9.3L47 29.9l2 3.8 1 3.4.3 1h.7v-.5l.5-7.2 1-8.7 1-11.2.3-3.2 1.6-3.8 3-2L61 2.6l2 2.9-.3 1.8-1.1 7.7L59 27.1l-1.5 8.2h.9l1-1.1 4.1-5.4 6.9-8.6 3-3.5L77 13l2.3-1.8h4.3l3.1 4.7-1.4 4.9-4.4 5.6-3.7 4.7-5.3 7.1-3.2 5.7.3.4h.7l12-2.6 6.4-1.1 7.6-1.3 3.5 1.6.4 1.6-1.4 3.4-8.2 2-9.6 2-14.3 3.3-.2.1.2.3 6.4.6 2.8.2h6.8l12.6 1 3.3 2 1.9 2.7-.3 2-5.1 2.6-6.8-1.6-16-3.8-5.4-1.3h-.8v.4l4.6 4.5 8.3 7.5L89 80.1l.5 2.4-1.3 2-1.4-.2-9.2-7-3.6-3-8-6.8h-.5v.7l1.8 2.7 9.8 14.7.5 4.5-.7 1.4-2.6 1-2.7-.6-5.8-8-6-9-4.7-8.2-.5.4-2.9 30.2-1.3 1.5-3 1.2-2.5-2-1.4-3 1.4-6.2 1.6-8 1.3-6.4 1.2-7.9.7-2.6v-.2H49L43 72l-9 12.3-7.2 7.6-1.7.7-3-1.5.3-2.8L24 86l10-12.8 6-7.9 4-4.6-.1-.5h-.3L17.2 77.4l-4.7.6-2-2 .2-3 1-1 8-5.5Z"/>
+    </svg>
+  `,
+  chatgpt: `
+    <svg class="recent-summarize-icon" width="14" height="14" viewBox="0 0 320 320" fill="currentColor" aria-hidden="true">
+      <path d="m297.06 130.97c7.26-21.79 4.76-45.66-6.85-65.48-17.46-30.4-52.56-46.04-86.84-38.68-15.25-17.18-37.16-26.95-60.13-26.81-35.04-.08-66.13 22.48-76.91 55.82-22.51 4.61-41.94 18.7-53.31 38.67-17.59 30.32-13.58 68.54 9.92 94.54-7.26 21.79-4.76 45.66 6.85 65.48 17.46 30.4 52.56 46.04 86.84 38.68 15.24 17.18 37.16 26.95 60.13 26.8 35.06.09 66.16-22.49 76.94-55.86 22.51-4.61 41.94-18.7 53.31-38.67 17.57-30.32 13.55-68.51-9.94-94.51zm-120.28 168.11c-14.03.02-27.62-4.89-38.39-13.88.49-.26 1.34-.73 1.89-1.07l63.72-36.8c3.26-1.85 5.26-5.32 5.24-9.07v-89.83l26.93 15.55c.29.14.48.42.52.74v74.39c-.04 33.08-26.83 59.9-59.91 59.97zm-128.84-55.03c-7.03-12.14-9.56-26.37-7.15-40.18.47.28 1.3.79 1.89 1.13l63.72 36.8c3.23 1.89 7.23 1.89 10.47 0l77.79-44.92v31.1c.02.32-.13.63-.38.83l-64.41 37.19c-28.69 16.52-65.33 6.7-81.92-21.95zm-16.77-139.09c7-12.16 18.05-21.46 31.21-26.29 0 .55-.03 1.52-.03 2.2v73.61c-.02 3.74 1.98 7.21 5.23 9.06l77.79 44.91-26.93 15.55c-.27.18-.61.21-.91.08l-64.42-37.22c-28.63-16.58-38.45-53.21-21.95-81.89zm221.26 51.49-77.79-44.92 26.93-15.54c.27-.18.61-.21.91-.08l64.42 37.19c28.68 16.57 38.51 53.26 21.94 81.94-7.01 12.14-18.05 21.44-31.2 26.28v-75.81c.03-3.74-1.96-7.2-5.2-9.06zm26.8-40.34c-.47-.29-1.3-.79-1.89-1.13l-63.72-36.8c-3.23-1.89-7.23-1.89-10.47 0l-77.79 44.92v-31.1c-.02-.32.13-.63.38-.83l64.41-37.16c28.69-16.55 65.37-6.7 81.91 22 6.99 12.12 9.52 26.31 7.15 40.1zm-168.51 55.43-26.94-15.55c-.29-.14-.48-.42-.52-.74v-74.39c.02-33.12 26.89-59.96 60.01-59.94 14.01 0 27.57 4.92 38.34 13.88-.49.26-1.33.73-1.89 1.07l-63.72 36.8c-3.26 1.85-5.26 5.31-5.24 9.06l-.04 89.79zm14.63-31.54 34.65-20.01 34.65 20v40.01l-34.65 20-34.65-20z"/>
+    </svg>
+  `,
+};
+
+const LLM_PROVIDERS = [
+  {
+    id: "chatgpt",
+    name: "ChatGPT",
+    urlTemplate: "https://chatgpt.com/?q={prompt}",
+    clipboardFallback: false,
+    openUrl: null,
+    icon: LLM_ICONS.chatgpt,
+  },
+  {
+    id: "claude",
+    name: "Claude",
+    urlTemplate: null,
+    clipboardFallback: true,
+    openUrl: "https://claude.ai/",
+    icon: LLM_ICONS.claude,
+  },
+];
+
+// Single shared prompt template, fetched once from /api/preferences.
+let llmPromptTemplate = LLM_DEFAULT_PROMPT;
+let llmPromptLoaded = false;
+// Currently-open dropdown (at most one); close on outside click.
+let llmOpenDropdown = null;
+
+async function loadLlmPrompt() {
+  if (llmPromptLoaded) return;
+  llmPromptLoaded = true;
+  const res = await sendMsg({ type: "GET_PREFERENCES" });
+  if (res?.success && res.data?.summarizePrompt) {
+    llmPromptTemplate = res.data.summarizePrompt;
+  }
+}
+
+function buildLlmLauncher(transcriptId, videoTitle) {
+  const wrapper = document.createElement("div");
+  wrapper.className = "recent-summarize";
+
+  const btn = document.createElement("button");
+  btn.type = "button";
+  btn.className = "recent-summarize-btn";
+  btn.title = "Summarize with LLM...";
+  btn.innerHTML = `
+    <svg width="14" height="14" viewBox="0 0 20 20" fill="none"
+         stroke="currentColor" stroke-width="1.75"
+         stroke-linecap="round" stroke-linejoin="round">
+      <path d="M10 2v2M10 16v2M2 10h2M16 10h2"/>
+      <path d="M4.93 4.93l1.41 1.41M13.66 13.66l1.41 1.41M4.93 15.07l1.41-1.41M13.66 6.34l1.41-1.41"/>
+      <circle cx="10" cy="10" r="2"/>
+    </svg>
+  `;
+  btn.addEventListener("click", (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    toggleLlmDropdown(wrapper, transcriptId, videoTitle);
+  });
+
+  wrapper.appendChild(btn);
+  return wrapper;
+}
+
+function closeLlmDropdown() {
+  if (llmOpenDropdown) {
+    if (typeof llmOpenDropdown._cleanup === "function") {
+      llmOpenDropdown._cleanup();
+    }
+    llmOpenDropdown.remove();
+    llmOpenDropdown = null;
+    document.removeEventListener("mousedown", onOutsideLlmClick, true);
+  }
+}
+
+function onOutsideLlmClick(e) {
+  if (llmOpenDropdown && !llmOpenDropdown.contains(e.target)) {
+    // Click on the toggle button itself handles its own close.
+    if (!(e.target.closest && e.target.closest(".recent-summarize-btn"))) {
+      closeLlmDropdown();
+    }
+  }
+}
+
+async function toggleLlmDropdown(wrapper, transcriptId, videoTitle) {
+  if (llmOpenDropdown && llmOpenDropdown.dataset.ownerWrapperId === wrapper.dataset.wrapperId) {
+    closeLlmDropdown();
+    return;
+  }
+  closeLlmDropdown();
+  loadLlmPrompt();
+
+  // Tag the wrapper so we can identify which row owns the open menu.
+  if (!wrapper.dataset.wrapperId) {
+    wrapper.dataset.wrapperId = String(Math.random()).slice(2);
+  }
+
+  const lastProvider =
+    (await chrome.storage.local.get(LLM_STORAGE_KEY))[LLM_STORAGE_KEY] || null;
+
+  const menu = document.createElement("div");
+  menu.className = "recent-summarize-menu";
+  menu.dataset.ownerWrapperId = wrapper.dataset.wrapperId;
+  const sorted = lastProvider
+    ? [
+        ...LLM_PROVIDERS.filter((p) => p.id === lastProvider),
+        ...LLM_PROVIDERS.filter((p) => p.id !== lastProvider),
+      ]
+    : LLM_PROVIDERS;
+
+  const pasteKey = /mac/i.test(navigator.userAgent) ? "\u2318+V" : "Ctrl+V";
+  menu.innerHTML = `
+    <div class="recent-summarize-menu-label">Summarize with</div>
+    ${sorted
+      .map(
+        (p) => `
+      <button type="button" class="recent-summarize-menu-item" data-provider="${p.id}">
+        ${p.icon}
+        <span class="recent-summarize-menu-name">${escapeHtml(p.name)}</span>
+        ${p.id === lastProvider ? '<span class="recent-summarize-menu-hint">last used</span>' : ""}
+        ${
+          p.clipboardFallback
+            ? `<span class="recent-summarize-menu-tip"><span class="recent-summarize-menu-tip-key">${pasteKey}</span> to paste transcript</span>`
+            : ""
+        }
+      </button>
+    `
+      )
+      .join("")}
+  `;
+  menu.addEventListener("click", (e) => e.stopPropagation());
+  menu.querySelectorAll("[data-provider]").forEach((btn) => {
+    btn.addEventListener("click", () => {
+      const providerId = btn.getAttribute("data-provider");
+      const provider = LLM_PROVIDERS.find((p) => p.id === providerId);
+      closeLlmDropdown();
+      launchWithProvider(provider, transcriptId, videoTitle);
+    });
+  });
+
+  // Portal the menu to <body> with fixed positioning so it escapes the
+  // recent-list scroll clip and sits above all sibling rows, matching the
+  // web-app LlmLauncher (createPortal + getBoundingClientRect).
+  document.body.appendChild(menu);
+  llmOpenDropdown = menu;
+  positionLlmDropdown(wrapper, menu);
+
+  // Reposition on scroll/resize so the menu stays pinned to its button.
+  const reposition = () => {
+    if (llmOpenDropdown === menu) positionLlmDropdown(wrapper, menu);
+  };
+  window.addEventListener("scroll", reposition, true);
+  window.addEventListener("resize", reposition);
+  menu._cleanup = () => {
+    window.removeEventListener("scroll", reposition, true);
+    window.removeEventListener("resize", reposition);
+  };
+
+  // Defer to next tick so the triggering click doesn't immediately close it
+  setTimeout(() => {
+    document.addEventListener("mousedown", onOutsideLlmClick, true);
+  }, 0);
+}
+
+function positionLlmDropdown(wrapper, menu) {
+  const btn = wrapper.querySelector(".recent-summarize-btn");
+  if (!btn) return;
+  const rect = btn.getBoundingClientRect();
+  // Measure menu after it's in the DOM so we can align its bottom-right
+  // to the button's top-right and keep it on-screen.
+  const menuWidth = menu.offsetWidth || 180;
+  const menuHeight = menu.offsetHeight || 100;
+  const margin = 8;
+
+  let left = rect.right - menuWidth;
+  if (left < margin) left = margin;
+  if (left + menuWidth > window.innerWidth - margin) {
+    left = window.innerWidth - menuWidth - margin;
+  }
+
+  let top = rect.top - menuHeight - 6;
+  // If it would clip the top of the viewport, fall back to below the button.
+  if (top < margin) top = rect.bottom + 6;
+
+  menu.style.top = `${top}px`;
+  menu.style.left = `${left}px`;
+}
+
+function flattenSegments(segments) {
+  return segments
+    .map((s, idx) => {
+      const prev = segments[idx - 1];
+      const speakerChanged = s.speaker && (!prev || prev.speaker !== s.speaker);
+      return speakerChanged ? `\n${s.speaker}: ${s.text}` : s.text;
+    })
+    .join(" ");
+}
+
+async function launchWithProvider(provider, transcriptId, videoTitle) {
+  try {
+    await chrome.storage.local.set({ [LLM_STORAGE_KEY]: provider.id });
+  } catch {
+    // storage failure — continue regardless
+  }
+
+  const res = await sendMsg({ type: "GET_TRANSCRIPT", id: transcriptId });
+  if (!res?.success || !res.data?.transcript) {
+    // No visible error surface in the list yet — log and bail. Future work:
+    // inline toast (see YTT-205 §3 error state).
+    console.warn("Summarize: failed to load transcript", res?.error);
+    return;
+  }
+
+  let transcriptText;
+  try {
+    const segments = JSON.parse(res.data.transcript);
+    transcriptText = flattenSegments(segments);
+  } catch {
+    console.warn("Summarize: transcript parse failed");
+    return;
+  }
+
+  const instruction = llmPromptTemplate.replace(/\{title\}/g, videoTitle);
+  const prompt = `${instruction}\n\nTranscript:\n\n${transcriptText}`;
+
+  if (provider.urlTemplate && !provider.clipboardFallback) {
+    const encoded = encodeURIComponent(prompt);
+    const maxLen = 6000;
+    const safe = encoded.length > maxLen ? encoded.slice(0, maxLen) : encoded;
+    const url = provider.urlTemplate.replace("{prompt}", safe);
+    chrome.tabs.create({ url, active: true });
+    return;
+  }
+
+  // Clipboard path (Claude): copy prompt, open provider for paste.
+  try {
+    await navigator.clipboard.writeText(prompt);
+  } catch {
+    // Clipboard blocked — still open the provider; user can re-summarize
+    // from the web app transcript page if needed.
+  }
+  if (provider.openUrl) {
+    chrome.tabs.create({ url: provider.openUrl, active: true });
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -333,6 +601,8 @@ async function loadRecent() {
         <path d="M7 4l6 6-6 6"/>
       </svg>` : ""}
     `;
+    // Summarize-with-LLM button — hover-reveal per row, mirrors web-app LlmLauncher
+    item.appendChild(buildLlmLauncher(t.id, t.title));
     el.recentList.appendChild(item);
 
     // Two-phase animation: visual fade, then smooth spatial collapse

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -786,12 +786,13 @@ async function init() {
       el.cloudNudge.hidden = true;
       el.localDetectedBanner.hidden = true;
 
-      if (authError) {
-        // Session expired or not signed in
+      const firstTime = !!serviceRes?.data?.firstTime;
+      if (authError && !firstTime) {
+        // Returning user whose session expired
         el.cloudOnboarding.hidden = true;
         el.cloudAuthError.hidden = false;
       } else {
-        // Service reachable but not signed in — first-time onboarding
+        // First-time install OR service reachable but no auth — show onboarding
         el.cloudOnboarding.hidden = false;
         el.cloudAuthError.hidden = true;
       }

--- a/extension/privacy-policy.md
+++ b/extension/privacy-policy.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-YouTube Transcriber is a browser extension that transcribes YouTube videos and Spotify podcast episodes. It supports two modes: **local mode** (all processing on your machine) and **cloud mode** (processing via transcribed.dev). You choose which mode to use in the extension settings.
+This browser extension transcribes videos and podcasts from supported web pages. It supports two modes: **local mode** (all processing on your machine) and **cloud mode** (processing via transcribed.dev). You choose which mode to use in the extension settings.
 
 ## Local Mode
 
@@ -20,15 +20,15 @@ Your local transcription service may use third-party transcription providers (su
 
 In cloud mode, the extension sends requests to `transcribed.dev` using your API key.
 
-- **Data sent to the cloud** — the URL of the video or podcast episode you want to transcribe is sent to transcribed.dev for processing. Your API key is sent with each request for authentication.
-- **Account required** — you need a transcribed.dev account and API key.
+- **Data sent to the cloud** — the URL of the video or podcast episode you want to transcribe is sent to transcribed.dev for processing. Your signed-in session is sent with each request for authentication.
+- **Account required** — you need a transcribed.dev account to use cloud mode.
 - **Transcripts stored on the server** — completed transcripts are stored in your transcribed.dev account so you can access them from any device.
 - **No analytics or tracking in the extension** — the extension itself does not use telemetry. The transcribed.dev service has its own privacy policy at https://www.transcribed.dev/privacy.
 
 ## Data Stored in Your Browser
 
 The extension uses Chrome's `storage` API to save:
-- **Sync storage** — your selected mode (local or cloud) and API key (if using cloud mode). This syncs across your Chrome devices.
+- **Sync storage** — your selected mode (local or cloud). This syncs across your Chrome devices.
 - **Session storage** — current transcription progress and queue (cleared when the browser closes).
 - **Local storage** — cached preferences (persisted across sessions).
 
@@ -37,7 +37,7 @@ This data is stored within your browser profile and managed by Chrome.
 ## Permissions
 
 The extension requests the following permissions:
-- **activeTab / tabs** — to detect which YouTube video or Spotify episode you're viewing.
+- **activeTab / tabs** — to detect which video or podcast episode you're viewing.
 - **storage** — to persist settings, transcription state, and preferences.
 - **sidePanel** — to display the transcription panel alongside your browsing.
 - **scripting** — to register content scripts that detect video/episode pages.

--- a/extension/store-listing.md
+++ b/extension/store-listing.md
@@ -4,21 +4,20 @@
 YouTube Transcriber
 
 ## Short Description (132 chars max)
-One-click transcription for YouTube videos and Spotify podcasts. Local or cloud — your choice.
+One-click transcription for videos and podcasts in your browser. Local or cloud — your choice.
 
 ## Detailed Description
-YouTube Transcriber adds a side panel to Chrome that lets you transcribe YouTube videos and Spotify podcast episodes with one click.
+A side panel for Chrome that turns any video or podcast you're watching or listening to into a full searchable transcript in one click.
 
 How it works:
 • Click the extension icon to open the side panel
-• Navigate to any YouTube video or Spotify podcast episode
+• Navigate to a supported video or podcast page
 • Hit "Transcribe" — get a full searchable transcript
 
 Two ways to use it:
 
 Cloud mode (easiest):
-• Sign up at transcribed.dev and get an API key
-• Paste your key in the extension settings
+• Sign in at transcribed.dev
 • Transcribe instantly — no setup, no installs
 • 10 free transcripts per month, upgrade for more
 
@@ -33,7 +32,7 @@ Key features:
 • Side panel stays open as you browse
 • Queue multiple videos for batch transcription
 • View recent transcripts without leaving your tab
-• Supports YouTube videos, Shorts, and Spotify podcast episodes
+• Works with major video platforms and podcast sites
 • Switch between local and cloud in settings
 
 ## Category


### PR DESCRIPTION
## Summary
- Port the web-app `LlmLauncher` into the extension side panel — hover any recent-list row to reveal a sparkle button that summarizes that transcript with Claude or ChatGPT. Extension stays a launcher: no transcript body is rendered inside the popup.
- Dropdown portals to `<body>` with `position: fixed` + computed coords (same technique as the web app's `createPortal`) so it escapes the recent-list scroll clip and draws above sibling rows.
- Security pass on `popup-shell.html`: iframe sandbox attributes + strict origin check on `postMessage` (drop `*` target origin).

## Changes
- `extension/popup.js` — `buildLlmLauncher` sparkle button, Claude/ChatGPT providers, last-used memory in `chrome.storage.local`, fixed-position dropdown with viewport-aware placement
- `extension/popup.css` — hover-reveal button, menu styling, Claude clipboard-hint tooltip (400ms delay, 200ms fade — same timing as web app)
- `extension/background.js` — new `GET_TRANSCRIPT` + `GET_PREFERENCES` message handlers so the popup never hits the cloud directly
- `extension/popup-shell.html` — iframe `sandbox` + `allow="clipboard-write"`; `postMessage` listener rejects anything not from `https://transcribed.dev` and targets that origin for the response
- `extension/manifest.json` — version 1.4.0 → 1.5.0

## Still open under YTT-205 (not in this PR)
- Destination adapter registry (Notion/Obsidian)
- Feature flag plumbing
- Split-button variant
- Per-row `⋯` secondary menu
- Paid-tier "Primary LLM of choice" (moved to out-of-scope on the ticket)

## Test plan
- [ ] Load `extension/dist/` as unpacked in Chrome → reload → side panel opens on a YouTube video
- [ ] Transcribe at least one video, confirm it appears in Recent
- [ ] Hover any Recent row → sparkle icon fades in
- [ ] Click sparkle → dropdown appears ABOVE the button, z-index above sibling rows, does not get clipped by the scroll container
- [ ] Pick ChatGPT → new tab to `chatgpt.com/?q=...` with the summarize prompt pre-filled
- [ ] Pick Claude → prompt copied to clipboard, `claude.ai/` opens in new tab, hover shows "⌘+V to paste transcript" tooltip after ~400ms
- [ ] Click a different row's sparkle → previous menu closes, new one opens
- [ ] Click outside the menu → closes
- [ ] Reload panel → last-used provider appears first with "last used" hint