### PR TITLE
YTT-224: in-panel magic-link sign-in for the extension

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -231,24 +231,47 @@ async function checkService() {
 async function sendMagicLink(email) {
   const trimmed = (email || "").trim();
   if (!trimmed || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmed)) {
-    return { ok: false, error: "Enter a valid email address." };
+    throw new Error("Enter a valid email address.");
   }
+  let res;
   try {
-    const res = await fetch(`${CLOUD_BASE}/api/auth/magic-link`, {
+    res = await fetch(`${CLOUD_BASE}/api/auth/magic-link`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ email: trimmed, source: "extension" }),
       signal: AbortSignal.timeout(10000),
     });
-    if (res.ok) return { ok: true };
-    let message = "Couldn't send the magic link. Try again.";
-    try {
-      const data = await res.json();
-      if (data?.error) message = data.error;
-    } catch { /* ignore */ }
-    return { ok: false, error: message };
   } catch {
-    return { ok: false, error: "Network error. Check your connection." };
+    throw new Error("Network error. Check your connection.");
+  }
+  if (res.ok) return { sent: true };
+  let message = "Couldn't send the magic link. Try again.";
+  try {
+    const data = await res.json();
+    if (data?.error) message = data.error;
+  } catch { /* ignore */ }
+  throw new Error(message);
+}
+
+/**
+ * Open transcribed.dev/auth/login in a small popup window with
+ * ?provider=google so the login page auto-triggers the Supabase Google
+ * OAuth redirect. The callback lands on /auth/extension-bridge which
+ * closes the popup; the side panel's offline poll restores the session.
+ */
+async function openGoogleSignin() {
+  const next = encodeURIComponent("/auth/extension-bridge");
+  const url = `${CLOUD_BASE}/auth/login?provider=google&next=${next}`;
+  try {
+    await chrome.windows.create({
+      url,
+      type: "popup",
+      width: 500,
+      height: 680,
+    });
+    return { opened: true };
+  } catch (err) {
+    throw new Error(err?.message || "Could not open the sign-in window.");
   }
 }
 
@@ -892,6 +915,9 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
       case "SEND_MAGIC_LINK":
         return await sendMagicLink(message.email);
+
+      case "OPEN_GOOGLE_SIGNIN":
+        return await openGoogleSignin();
 
       case "TRANSCRIBE": {
         if (!validHttpUrl(message.url)) {

--- a/extension/background.js
+++ b/extension/background.js
@@ -221,6 +221,37 @@ async function checkService() {
   return health;
 }
 
+/**
+ * Send a Supabase magic-link email to `email`, keeping the user on their
+ * current tab. Cloud endpoint sets the post-auth redirect so the email
+ * link completes the session on transcribed.dev (cross-origin cookie
+ * already allowed by host_permissions), and the side panel's offline
+ * poller picks up the new session automatically.
+ */
+async function sendMagicLink(email) {
+  const trimmed = (email || "").trim();
+  if (!trimmed || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmed)) {
+    return { ok: false, error: "Enter a valid email address." };
+  }
+  try {
+    const res = await fetch(`${CLOUD_BASE}/api/auth/magic-link`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: trimmed, source: "extension" }),
+      signal: AbortSignal.timeout(10000),
+    });
+    if (res.ok) return { ok: true };
+    let message = "Couldn't send the magic link. Try again.";
+    try {
+      const data = await res.json();
+      if (data?.error) message = data.error;
+    } catch { /* ignore */ }
+    return { ok: false, error: message };
+  } catch {
+    return { ok: false, error: "Network error. Check your connection." };
+  }
+}
+
 /** Probe localhost to see if a local instance is running. */
 async function detectLocalInstance() {
   try {
@@ -858,6 +889,9 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
       case "CHECK_SERVICE":
         return await checkService();
+
+      case "SEND_MAGIC_LINK":
+        return await sendMagicLink(message.email);
 
       case "TRANSCRIBE": {
         if (!validHttpUrl(message.url)) {

--- a/extension/background.js
+++ b/extension/background.js
@@ -262,17 +262,60 @@ async function sendMagicLink(email) {
 async function openGoogleSignin() {
   const next = encodeURIComponent("/auth/extension-bridge");
   const url = `${CLOUD_BASE}/auth/login?provider=google&next=${next}`;
+  const width = 420;
+  const height = 560;
+
+  // Center the popup over whichever window the user is currently in.
+  let left;
+  let top;
   try {
-    await chrome.windows.create({
+    const current = await chrome.windows.getCurrent();
+    if (current?.width && current?.height) {
+      left = Math.round((current.left ?? 0) + (current.width - width) / 2);
+      top = Math.round((current.top ?? 0) + (current.height - height) / 2);
+    }
+  } catch { /* fall back to Chrome default placement */ }
+
+  let win;
+  try {
+    win = await chrome.windows.create({
       url,
       type: "popup",
-      width: 500,
-      height: 680,
+      width,
+      height,
+      ...(left != null && top != null ? { left, top } : {}),
     });
-    return { opened: true };
   } catch (err) {
     throw new Error(err?.message || "Could not open the sign-in window.");
   }
+
+  // Auto-close the popup when it reaches the extension-bridge URL. Falling
+  // back to the bridge page's own window.close() isn't 100% reliable across
+  // browsers, so we close the window from the extension side too.
+  const windowId = win.id;
+  if (windowId != null) {
+    const onUpdated = (_tabId, changeInfo, tab) => {
+      if (tab?.windowId !== windowId) return;
+      const u = changeInfo.url || tab.url || "";
+      if (u.includes("/auth/extension-bridge")) {
+        chrome.tabs.onUpdated.removeListener(onUpdated);
+        // Brief delay so Supabase sets the session cookie before we close.
+        setTimeout(() => {
+          chrome.windows.remove(windowId).catch(() => { /* already closed */ });
+        }, 400);
+      }
+    };
+    const onRemoved = (closedId) => {
+      if (closedId === windowId) {
+        chrome.tabs.onUpdated.removeListener(onUpdated);
+        chrome.windows.onRemoved.removeListener(onRemoved);
+      }
+    };
+    chrome.tabs.onUpdated.addListener(onUpdated);
+    chrome.windows.onRemoved.addListener(onRemoved);
+  }
+
+  return { opened: true };
 }
 
 /** Probe localhost to see if a local instance is running. */

--- a/extension/popup.css
+++ b/extension/popup.css
@@ -975,20 +975,87 @@ body::-webkit-scrollbar-thumb:hover {
   cursor: not-allowed;
 }
 
+/* Cloud sign-in card — mirrors the /auth/login layout in the web app. */
+.cloud-auth-title {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.9);
+  text-align: center;
+}
+.cloud-auth-subtitle {
+  margin: 4px 0 0;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.45);
+  text-align: center;
+}
+
+.cloud-auth-card {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 280px;
+  margin: 16px auto 0;
+}
+.cloud-auth-card[hidden] {
+  display: none;
+}
+
+.btn-google {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  padding: 10px 14px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.04);
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+.btn-google:hover {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.22);
+}
+.btn-google:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.cloud-auth-divider {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 14px 0;
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.3);
+}
+.cloud-auth-divider::before,
+.cloud-auth-divider::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
 .cloud-auth-form {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  margin-top: 12px;
   width: 100%;
-  max-width: 260px;
+}
+.cloud-auth-form[hidden] {
+  display: none;
 }
 .cloud-auth-email {
   width: 100%;
-  padding: 8px 12px;
-  border: 1px solid rgba(255, 255, 255, 0.14);
+  padding: 10px 12px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
   border-radius: 8px;
-  background: rgba(0, 0, 0, 0.25);
+  background: rgba(0, 0, 0, 0.3);
   color: var(--text);
   font-size: 13px;
   outline: none;
@@ -998,29 +1065,51 @@ body::-webkit-scrollbar-thumb:hover {
   color: rgba(255, 255, 255, 0.25);
 }
 .cloud-auth-email:focus {
-  border-color: rgba(255, 255, 255, 0.3);
-  background: rgba(0, 0, 0, 0.35);
+  border-color: rgba(217, 185, 112, 0.5);
+  background: rgba(0, 0, 0, 0.4);
 }
-.cloud-auth-form .btn-cloud-signin {
-  margin-top: 0;
+
+.btn-auth-primary {
   width: 100%;
+  padding: 10px 14px;
+  border: none;
+  border-radius: 8px;
+  background: var(--accent, #d9b970);
+  color: #fff;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: opacity 0.15s;
 }
+.btn-auth-primary:hover {
+  opacity: 0.9;
+}
+.btn-auth-primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .cloud-auth-error {
-  margin: 0;
+  margin: 4px 0 0;
   font-size: 11px;
   color: rgba(248, 113, 113, 0.85);
   text-align: left;
 }
 
 .cloud-auth-sent {
-  margin-top: 4px;
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 4px;
+  width: 100%;
+  max-width: 280px;
+  margin: 16px auto 0;
+}
+.cloud-auth-sent[hidden] {
+  display: none;
 }
 .cloud-auth-resend {
-  margin-top: 6px;
+  margin-top: 10px;
   padding: 0;
   border: none;
   background: none;

--- a/extension/popup.css
+++ b/extension/popup.css
@@ -1350,35 +1350,85 @@ body::-webkit-scrollbar-thumb:hover {
    toggles this to get auto-paste instead of ⌘V. Sub-text explains the
    plugin requirement so users don't flip the toggle blind. */
 .obsidian-advuri-row {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
   padding: 6px 10px 10px;
   user-select: none;
 }
 .obsidian-advuri-row[hidden] {
   display: none;
 }
+.obsidian-advuri-summary {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgba(255, 255, 255, 0.35);
+  list-style: none;
+  transition: color 0.15s;
+  padding: 4px 0;
+}
+.obsidian-advuri-summary::-webkit-details-marker {
+  display: none;
+}
+.obsidian-advuri-summary::before {
+  content: "▸";
+  font-size: 9px;
+  color: rgba(255, 255, 255, 0.3);
+  transition: transform 0.15s, color 0.15s;
+}
+.obsidian-advuri-row[open] .obsidian-advuri-summary::before {
+  transform: rotate(90deg);
+}
+.obsidian-advuri-summary:hover {
+  color: rgba(255, 255, 255, 0.6);
+}
 .obsidian-advuri-label {
   display: flex;
   align-items: center;
   gap: 8px;
   cursor: pointer;
+  margin-top: 10px;
 }
 .obsidian-advuri-input {
   flex-shrink: 0;
   width: 14px;
   height: 14px;
-  accent-color: var(--accent);
+  appearance: none;
+  -webkit-appearance: none;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 3px;
+  background: rgba(0, 0, 0, 0.3);
   cursor: pointer;
   margin: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.15s, border-color 0.15s;
+}
+.obsidian-advuri-input:hover {
+  border-color: rgba(255, 255, 255, 0.32);
+}
+.obsidian-advuri-input:checked {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+.obsidian-advuri-input:checked::after {
+  content: "";
+  width: 4px;
+  height: 8px;
+  border: solid #fff;
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg) translate(-1px, -1px);
 }
 .obsidian-advuri-text {
   font-size: 12px;
   color: rgba(255, 255, 255, 0.75);
 }
 .obsidian-advuri-sub {
-  margin: 0 0 0 22px;
+  margin: 4px 0 0 22px;
   font-size: 11px;
   line-height: 1.4;
   color: var(--muted-3);

--- a/extension/popup.css
+++ b/extension/popup.css
@@ -963,11 +963,78 @@ body::-webkit-scrollbar-thumb:hover {
   font-size: 13px;
   font-weight: 500;
   text-decoration: none;
+  cursor: pointer;
   transition: background 0.15s, border-color 0.15s;
 }
 .btn-cloud-signin:hover {
   background: rgba(255, 255, 255, 0.16);
   border-color: var(--border-hover);
+}
+.btn-cloud-signin:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.cloud-auth-form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 12px;
+  width: 100%;
+  max-width: 260px;
+}
+.cloud-auth-email {
+  width: 100%;
+  padding: 8px 12px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.25);
+  color: var(--text);
+  font-size: 13px;
+  outline: none;
+  transition: border-color 0.15s, background 0.15s;
+}
+.cloud-auth-email::placeholder {
+  color: rgba(255, 255, 255, 0.25);
+}
+.cloud-auth-email:focus {
+  border-color: rgba(255, 255, 255, 0.3);
+  background: rgba(0, 0, 0, 0.35);
+}
+.cloud-auth-form .btn-cloud-signin {
+  margin-top: 0;
+  width: 100%;
+}
+.cloud-auth-error {
+  margin: 0;
+  font-size: 11px;
+  color: rgba(248, 113, 113, 0.85);
+  text-align: left;
+}
+
+.cloud-auth-sent {
+  margin-top: 4px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+.cloud-auth-resend {
+  margin-top: 6px;
+  padding: 0;
+  border: none;
+  background: none;
+  color: rgba(255, 255, 255, 0.35);
+  font-size: 12px;
+  cursor: pointer;
+  transition: color 0.15s;
+}
+.cloud-auth-resend:hover {
+  color: rgba(255, 255, 255, 0.6);
+}
+.cloud-auth-resend:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 
 /* Cloud account link in settings */

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -39,17 +39,36 @@
         <div id="cloudOnboarding">
           <p class="offline-heading">Get started</p>
           <p class="offline-sub">Transcribe 10 videos/month for free</p>
-          <a class="btn-cloud-signin" href="https://www.transcribed.dev/auth/login" target="_blank">
-            Sign in at transcribed.dev →
-          </a>
         </div>
         <!-- Shown when the session has expired -->
         <div id="cloudAuthError" hidden>
           <p class="offline-heading">Signed out</p>
           <p class="offline-sub">Your session expired — sign in again to continue.</p>
-          <a class="btn-cloud-signin" href="https://www.transcribed.dev/auth/login" target="_blank">
-            Sign in again →
-          </a>
+        </div>
+        <!-- In-panel magic-link form: keeps the user on YouTube instead of
+             bouncing them to transcribed.dev/auth/login in a new tab. -->
+        <form id="cloudAuthForm" class="cloud-auth-form">
+          <input
+            type="email"
+            id="cloudAuthEmail"
+            class="cloud-auth-email"
+            placeholder="you@email.com"
+            autocomplete="email"
+            spellcheck="false"
+            required
+          >
+          <button type="submit" id="cloudAuthSubmit" class="btn-cloud-signin">Sign in</button>
+          <p id="cloudAuthErrorMsg" class="cloud-auth-error" hidden></p>
+        </form>
+        <!-- "Check your email" success state — stays in-panel while the user
+             clicks the magic link in a new tab. The existing offline-polling
+             detects session return and re-runs init(). -->
+        <div id="cloudAuthSent" class="cloud-auth-sent" hidden>
+          <p class="offline-heading">Check your email</p>
+          <p class="offline-sub">
+            Sent a sign-in link to <span id="cloudAuthSentEmail"></span>. Click it to finish — you can stay here.
+          </p>
+          <button type="button" id="cloudAuthResend" class="cloud-auth-resend">Resend</button>
         </div>
       </div>
 

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -9,11 +9,6 @@
   <div class="popup">
     <!-- No Service -->
     <div id="stateNoService" class="state state-offline" hidden>
-      <div class="offline-orb">
-        <div class="offline-orb-ring"></div>
-        <div class="offline-orb-dot"></div>
-      </div>
-
       <!-- Local mode offline -->
       <div id="offlineLocalMsg">
         <p class="offline-heading">Waiting for server</p>
@@ -33,40 +28,44 @@
         </div>
       </div>
 
-      <!-- Cloud mode offline / onboarding -->
+      <!-- Cloud mode: mini sign-in card mirroring /auth/login -->
       <div id="offlineCloudMsg" hidden>
-        <!-- Shown when user has no session (first-time onboarding) -->
+        <!-- Heading + subtitle swap between onboarding and signed-out states.
+             Kept as distinct elements (rather than a single text swap) so the
+             init() code keeps its existing hide/show contract. -->
         <div id="cloudOnboarding">
-          <p class="offline-heading">Get started</p>
-          <p class="offline-sub">Transcribe 10 videos/month for free</p>
+          <h2 class="cloud-auth-title">Sign in</h2>
+          <p class="cloud-auth-subtitle">Transcribe 10 videos/month for free.</p>
         </div>
-        <!-- Shown when the session has expired -->
         <div id="cloudAuthError" hidden>
-          <p class="offline-heading">Signed out</p>
-          <p class="offline-sub">Your session expired — sign in again to continue.</p>
+          <h2 class="cloud-auth-title">Session expired</h2>
+          <p class="cloud-auth-subtitle">Sign back in to continue.</p>
         </div>
-        <!-- In-panel magic-link form: keeps the user on YouTube instead of
-             bouncing them to transcribed.dev/auth/login in a new tab. -->
-        <form id="cloudAuthForm" class="cloud-auth-form">
-          <input
-            type="email"
-            id="cloudAuthEmail"
-            class="cloud-auth-email"
-            placeholder="you@email.com"
-            autocomplete="email"
-            spellcheck="false"
-            required
-          >
-          <button type="submit" id="cloudAuthSubmit" class="btn-cloud-signin">Sign in</button>
-          <p id="cloudAuthErrorMsg" class="cloud-auth-error" hidden></p>
-        </form>
-        <!-- "Check your email" success state — stays in-panel while the user
-             clicks the magic link in a new tab. The existing offline-polling
-             detects session return and re-runs init(). -->
+
+        <div id="cloudAuthCard" class="cloud-auth-card">
+          <button type="button" id="cloudAuthGoogle" class="btn-google">
+            Continue with Google
+          </button>
+          <div class="cloud-auth-divider"><span>or</span></div>
+          <form id="cloudAuthForm" class="cloud-auth-form">
+            <input
+              type="email"
+              id="cloudAuthEmail"
+              class="cloud-auth-email"
+              placeholder="Email address"
+              autocomplete="email"
+              spellcheck="false"
+              required
+            >
+            <button type="submit" id="cloudAuthSubmit" class="btn-auth-primary">Send magic link</button>
+            <p id="cloudAuthErrorMsg" class="cloud-auth-error" hidden></p>
+          </form>
+        </div>
+
         <div id="cloudAuthSent" class="cloud-auth-sent" hidden>
-          <p class="offline-heading">Check your email</p>
-          <p class="offline-sub">
-            Sent a sign-in link to <span id="cloudAuthSentEmail"></span>. Click it to finish — you can stay here.
+          <h2 class="cloud-auth-title">Check your email</h2>
+          <p class="cloud-auth-subtitle">
+            Sent a sign-in link to <span id="cloudAuthSentEmail"></span>.
           </p>
           <button type="button" id="cloudAuthResend" class="cloud-auth-resend">Resend</button>
         </div>

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -180,7 +180,8 @@
           <input id="obsidianVaultInput" class="obsidian-vault-input" type="text" placeholder="e.g. MyVault" autocomplete="off" spellcheck="false" />
           <span id="obsidianVaultSaved" class="obsidian-vault-saved" hidden>Saved</span>
         </div>
-        <div id="obsidianAdvUriRow" class="obsidian-advuri-row" hidden>
+        <details id="obsidianAdvUriRow" class="obsidian-advuri-row" hidden>
+          <summary class="obsidian-advuri-summary">Advanced</summary>
           <label class="obsidian-advuri-label">
             <input id="obsidianAdvUriInput" class="obsidian-advuri-input" type="checkbox" />
             <span class="obsidian-advuri-text">Use Advanced URI plugin</span>
@@ -190,7 +191,7 @@
             <a class="obsidian-advuri-link" href="https://github.com/Vinzent03/obsidian-advanced-uri" target="_blank" rel="noopener">Advanced URI</a>
             community plugin.
           </p>
-        </div>
+        </details>
       </div>
     </div>
 

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -37,6 +37,8 @@ const el = {
   offlineCloudMsg: document.getElementById("offlineCloudMsg"),
   cloudOnboarding: document.getElementById("cloudOnboarding"),
   cloudAuthError: document.getElementById("cloudAuthError"),
+  cloudAuthCard: document.getElementById("cloudAuthCard"),
+  cloudAuthGoogle: document.getElementById("cloudAuthGoogle"),
   cloudAuthForm: document.getElementById("cloudAuthForm"),
   cloudAuthEmail: document.getElementById("cloudAuthEmail"),
   cloudAuthSubmit: document.getElementById("cloudAuthSubmit"),
@@ -1680,12 +1682,12 @@ async function init() {
         el.cloudOnboarding.hidden = false;
         el.cloudAuthError.hidden = true;
       }
-      // Reset the in-panel magic-link form so it's ready for the next attempt
+      // Reset the in-panel sign-in card so it's ready for the next attempt
       // (or keep the "check your email" confirmation visible if we just sent).
       if (!el.cloudAuthSent.hidden) {
-        el.cloudAuthForm.hidden = true;
+        el.cloudAuthCard.hidden = true;
       } else {
-        el.cloudAuthForm.hidden = false;
+        el.cloudAuthCard.hidden = false;
         el.cloudAuthErrorMsg.hidden = true;
       }
 
@@ -1858,11 +1860,14 @@ el.btnTranscribe.addEventListener("click", doTranscribe);
 el.btnRetry.addEventListener("click", doTranscribe);
 el.btnCheckAgain.addEventListener("click", init);
 
-// In-panel magic-link sign-in. Keeps the user on the current YouTube tab
-// — they get an email, click the link (which auto-closes its tab), and
-// the existing `startOfflinePolling()` loop picks up the restored session
-// and reruns init().
+// In-panel sign-in. The user never leaves the YouTube tab:
+// — Google: a small popup window runs the OAuth flow and closes itself.
+// — Magic link: we POST to /api/auth/magic-link; the email link lands on
+//   /auth/extension-bridge which auto-closes.
+// In both cases the existing `startOfflinePolling()` loop picks up the
+// restored session within ~5s and reruns init().
 let lastAuthEmail = "";
+
 async function sendMagicLink(email) {
   el.cloudAuthSubmit.disabled = true;
   el.cloudAuthResend.disabled = true;
@@ -1879,7 +1884,7 @@ async function sendMagicLink(email) {
     el.cloudAuthSentEmail.textContent = email;
     el.cloudOnboarding.hidden = true;
     el.cloudAuthError.hidden = true;
-    el.cloudAuthForm.hidden = true;
+    el.cloudAuthCard.hidden = true;
     el.cloudAuthSent.hidden = false;
     return;
   }
@@ -1898,6 +1903,21 @@ el.cloudAuthForm.addEventListener("submit", (e) => {
 el.cloudAuthResend.addEventListener("click", () => {
   if (!lastAuthEmail) return;
   sendMagicLink(lastAuthEmail);
+});
+
+// Google OAuth: open /auth/login?provider=google in a small popup window
+// so the YouTube tab stays focused. The login page auto-triggers the
+// Supabase Google flow; the callback redirects to /auth/extension-bridge
+// which closes the popup.
+el.cloudAuthGoogle.addEventListener("click", async () => {
+  el.cloudAuthGoogle.disabled = true;
+  const res = await sendMsg({ type: "OPEN_GOOGLE_SIGNIN" });
+  el.cloudAuthGoogle.disabled = false;
+  if (!res?.success) {
+    el.cloudAuthErrorMsg.textContent =
+      res?.error || "Couldn't open the Google sign-in window.";
+    el.cloudAuthErrorMsg.hidden = false;
+  }
 });
 
 // "Switch to self-hosted" — auto-switch to local mode

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -37,6 +37,13 @@ const el = {
   offlineCloudMsg: document.getElementById("offlineCloudMsg"),
   cloudOnboarding: document.getElementById("cloudOnboarding"),
   cloudAuthError: document.getElementById("cloudAuthError"),
+  cloudAuthForm: document.getElementById("cloudAuthForm"),
+  cloudAuthEmail: document.getElementById("cloudAuthEmail"),
+  cloudAuthSubmit: document.getElementById("cloudAuthSubmit"),
+  cloudAuthErrorMsg: document.getElementById("cloudAuthErrorMsg"),
+  cloudAuthSent: document.getElementById("cloudAuthSent"),
+  cloudAuthSentEmail: document.getElementById("cloudAuthSentEmail"),
+  cloudAuthResend: document.getElementById("cloudAuthResend"),
   localDetectedBanner: document.getElementById("localDetectedBanner"),
   btnUseLocal: document.getElementById("btnUseLocal"),
   cloudNudge: document.getElementById("cloudNudge"),
@@ -1673,6 +1680,14 @@ async function init() {
         el.cloudOnboarding.hidden = false;
         el.cloudAuthError.hidden = true;
       }
+      // Reset the in-panel magic-link form so it's ready for the next attempt
+      // (or keep the "check your email" confirmation visible if we just sent).
+      if (!el.cloudAuthSent.hidden) {
+        el.cloudAuthForm.hidden = true;
+      } else {
+        el.cloudAuthForm.hidden = false;
+        el.cloudAuthErrorMsg.hidden = true;
+      }
 
       // Auto-detect local instance and show banner
       const localRes = await sendMsg({ type: "DETECT_LOCAL" });
@@ -1842,6 +1857,48 @@ async function processQueue() {
 el.btnTranscribe.addEventListener("click", doTranscribe);
 el.btnRetry.addEventListener("click", doTranscribe);
 el.btnCheckAgain.addEventListener("click", init);
+
+// In-panel magic-link sign-in. Keeps the user on the current YouTube tab
+// — they get an email, click the link (which auto-closes its tab), and
+// the existing `startOfflinePolling()` loop picks up the restored session
+// and reruns init().
+let lastAuthEmail = "";
+async function sendMagicLink(email) {
+  el.cloudAuthSubmit.disabled = true;
+  el.cloudAuthResend.disabled = true;
+  el.cloudAuthErrorMsg.hidden = true;
+  el.cloudAuthErrorMsg.textContent = "";
+
+  const res = await sendMsg({ type: "SEND_MAGIC_LINK", email });
+
+  el.cloudAuthSubmit.disabled = false;
+  el.cloudAuthResend.disabled = false;
+
+  if (res?.success) {
+    lastAuthEmail = email;
+    el.cloudAuthSentEmail.textContent = email;
+    el.cloudOnboarding.hidden = true;
+    el.cloudAuthError.hidden = true;
+    el.cloudAuthForm.hidden = true;
+    el.cloudAuthSent.hidden = false;
+    return;
+  }
+  el.cloudAuthErrorMsg.textContent =
+    res?.error || "Couldn't send the magic link. Try again.";
+  el.cloudAuthErrorMsg.hidden = false;
+}
+
+el.cloudAuthForm.addEventListener("submit", (e) => {
+  e.preventDefault();
+  const email = el.cloudAuthEmail.value.trim();
+  if (!email) return;
+  sendMagicLink(email);
+});
+
+el.cloudAuthResend.addEventListener("click", () => {
+  if (!lastAuthEmail) return;
+  sendMagicLink(lastAuthEmail);
+});
 
 // "Switch to self-hosted" — auto-switch to local mode
 el.btnUseLocal.addEventListener("click", async () => {


### PR DESCRIPTION
## Summary

Stop kicking the user out of their YouTube tab when the extension session expires. The side panel's signed-out and onboarding states now render an email input + "Sign in" button inline. On submit we POST to a new cloud endpoint (`/api/auth/magic-link`, see [companion PR](https://github.com/lifesized/youtube-transcriber-cloud/pulls?q=head%3Alifesized%2Fytt-224-magic-link-endpoint)) which sends a Supabase magic link. The email link lands on a small bridge page that auto-closes so focus returns to the original tab. The side panel's existing 5-second offline poll picks up the new session without any manual action.

Also dropped the "→" arrow from the button label — the form no longer navigates anywhere, so the arrow is misleading.

## Test plan

- [ ] Install the extension; open a YouTube video, then clear cookies for transcribed.dev.
- [ ] Side panel shows "Signed out" with an email field.
- [ ] Enter a valid email → "Sign in" → "Check your email" confirmation appears.
- [ ] Invalid email → inline error under the button.
- [ ] Click the link in the email; the new tab auto-closes.
- [ ] YouTube tab remains focused; side panel refreshes to the normal transcribe UI within ~5s.
- [ ] Resend button works.
- [ ] Local mode offline state still shows `npm run dev` copy (no regression).

## Companion PR

Requires the cloud endpoint: `lifesized/youtube-transcriber-cloud` branch `lifesized/ytt-224-magic-link-endpoint`.