### PR TITLE
Fix: oEmbed 401 falls back to placeholder metadata (YTT-319)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-05-13
+
+### Fixed
+- **Embed-disabled videos no longer fail with "private or restricted" (YTT-319)** — `lib/transcript.ts:fetchMetadata()` was throwing on oEmbed 401 with a misleading "private or restricted — metadata unavailable" error, and because metadata + transcript run in `Promise.all`, the entire transcribe operation failed. But oEmbed 401s happen on **publicly viewable** videos whenever the channel has disabled embed (common) or the video is age-restricted. Confirmed via direct curl: `IFElGv5ZmRM` (Hormozi-adjacent talk) → 401 every time, both URL formats and with/without browser User-Agent; a normal video (`dQw4w9WgXcQ`) → 200. Now `fetchMetadata` falls back to placeholder metadata (`title: "Untitled"`, `author: "Unknown"`, thumbnail URL guessed from videoId) on any non-OK response other than 404. 404 still throws "video not found". Transcript path is independent of oEmbed, so the user gets their transcript with a placeholder title instead of a wrongful error.
+
 ## 2026-05-08
 
 ### Changed

--- a/lib/transcript.ts
+++ b/lib/transcript.ts
@@ -108,37 +108,46 @@ async function fetchWithRetry(
 
 /**
  * Fetch video metadata using the YouTube oEmbed API (no API key required).
+ *
+ * oEmbed returns 401 for embed-disabled and age-restricted videos even
+ * when the video is publicly viewable. In those cases we fall back to
+ * placeholder metadata so transcript fetching can still proceed — the
+ * transcript path is independent of oEmbed. Only 404 (video gone) is
+ * treated as fatal.
  */
 export async function fetchMetadata(videoId: string): Promise<VideoMetadata> {
   const oembedUrl = `https://www.youtube.com/oembed?url=https://www.youtube.com/watch?v=${videoId}&format=json`;
 
   const res = await fetch(oembedUrl, { signal: AbortSignal.timeout(5000) });
 
-  if (!res.ok) {
-    if (res.status === 401) {
-      throw new Error(
-        `Video ${videoId} is private or restricted — metadata unavailable.`
-      );
-    }
-    if (res.status === 404) {
-      throw new Error(
-        `Video ${videoId} not found — it may have been removed.`
-      );
-    }
+  if (res.ok) {
+    const data = await res.json();
+    return {
+      videoId,
+      title: data.title ?? "Untitled",
+      author: data.author_name ?? "Unknown",
+      channelUrl: data.author_url ?? "",
+      thumbnailUrl:
+        data.thumbnail_url ?? `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`,
+    };
+  }
+
+  if (res.status === 404) {
     throw new Error(
-      `Failed to fetch metadata for video ${videoId} (HTTP ${res.status}).`
+      `Video ${videoId} not found — it may have been removed.`
     );
   }
 
-  const data = await res.json();
+  console.warn(
+    `[transcript] oEmbed returned ${res.status} for ${videoId} — using placeholder metadata.`
+  );
 
   return {
     videoId,
-    title: data.title ?? "Untitled",
-    author: data.author_name ?? "Unknown",
-    channelUrl: data.author_url ?? "",
-    thumbnailUrl:
-      data.thumbnail_url ?? `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`,
+    title: "Untitled",
+    author: "Unknown",
+    channelUrl: "",
+    thumbnailUrl: `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`,
   };
 }
 


### PR DESCRIPTION
## Summary

- `lib/transcript.ts:fetchMetadata()` no longer throws on YouTube oEmbed 4xx (other than 404). Embed-disabled and age-restricted videos legitimately return 401 from oEmbed even though they're publicly viewable, and the previous "private or restricted — metadata unavailable" error was misleading and blocked the entire transcribe operation (metadata + transcript run in `Promise.all`).
- Now returns placeholder metadata (`title: "Untitled"`, `author: "Unknown"`, thumbnail URL guessed from videoId) on non-404 errors. Transcript path is independent of oEmbed, so users get their transcript with placeholder title instead of a wrongful error.
- Confirmed via direct curl: `IFElGv5ZmRM` → 401 every variation; `dQw4w9WgXcQ` (normal video) → 200.

## Why the misleading error existed

oEmbed's 401 semantics aren't actually "private" — they're "we can't tell you about this video," which covers embed-disabled, age-restricted, geo-restricted, and miscellaneous YouTube anti-bot. The hard-coded "private or restricted" string assumed a specific meaning oEmbed doesn't actually carry.

## Test plan

- [x] `npm run lint` passes (only pre-existing `<img>` warning in `app/page.tsx`)
- [x] Local dev server test: transcribed `https://www.youtube.com/watch?v=IFElGv5ZmRM` end-to-end via self-hosted mode. Server logged `[transcript] oEmbed returned 401 for IFElGv5ZmRM — using placeholder metadata.`, transcript saved successfully, library shows real title (from extension page-scrape) + "Unknown" author (placeholder)
- [x] Health check: all components healthy
- [ ] Port same diff to cloud repo `youtube-transcriber-cloud/lib/transcript.ts` (follow-up PR after merge)

## Out of scope (deferred per YTT-319)

- yt-dlp fallback for full metadata extraction on embed-disabled videos (would recover real title/author) — defer until users complain about "Unknown" author entries
- Send metadata from extension's `ytInitialPlayerResponse` — bigger protocol change
- User-Agent header on oEmbed fetch — confirmed NOT the fix (401 happens with/without browser UA)

Linear: YTT-319