### PR TITLE
Retry YouTube downloads with format 18 after HTTP 403

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-07-15
+
+### Fixed
+- **YouTube audio-only HTTP 403 fallback** — Local Whisper downloads now retry with YouTube's progressive format 18 when separate audio-only streams are rejected with HTTP 403. This restores transcription for videos such as `UIEzt1gGCmk` whose metadata and progressive stream are available but whose DASH audio streams are forbidden.
+
 ## 2026-05-13
 
 ### Fixed

--- a/lib/whisper.ts
+++ b/lib/whisper.ts
@@ -292,7 +292,7 @@ export async function downloadAudio(videoId: string, outputDir: string, onProgre
       onProgress?.({ stage: "transcribing", progress: 40, statusText: "Transcribing with Whisper..." });
       return audioPath;
     } catch (err) {
-      const raw = err instanceof Error ? err.message : String(err);
+      let raw = err instanceof Error ? err.message : String(err);
       const isNetworkError = /unable to download webpage|urlopen error|timed out|network is unreachable|name or service not known|temporary failure/i.test(raw);
 
       if (isNetworkError && attempt < maxAttempts) {
@@ -317,6 +317,21 @@ export async function downloadAudio(videoId: string, outputDir: string, onProgre
         } catch (cookieErr) {
           const cookieRaw = cookieErr instanceof Error ? cookieErr.message : String(cookieErr);
           console.log(`[whisper] Cookie retry also failed: ${cookieRaw.slice(0, 300)}`);
+        }
+      }
+
+      if (/HTTP Error 403|403: Forbidden/i.test(raw)) {
+        console.log("[whisper] Audio-only stream returned HTTP 403; trying progressive format 18...");
+        try {
+          const fallbackArgs = ["-f", "18", ...baseArgs];
+          const { stderr } = await execFileAsync(YTDLP_PATH, fallbackArgs, { timeout: 120000 });
+          if (stderr) console.log(`[whisper] yt-dlp stderr (format 18 fallback): ${stderr.slice(0, 500)}`);
+          const audioPath = path.join(outputDir, `${videoId}.mp3`);
+          await fs.access(audioPath);
+          onProgress?.({ stage: "transcribing", progress: 40, statusText: "Transcribing with Whisper..." });
+          return audioPath;
+        } catch (fallbackErr) {
+          raw = fallbackErr instanceof Error ? fallbackErr.message : String(fallbackErr);
         }
       }
 

--- a/tests/whisper-download.test.ts
+++ b/tests/whisper-download.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+test("falls back to progressive format 18 after an audio-only HTTP 403", async (t) => {
+  const fixtureDir = await mkdtemp(path.join(tmpdir(), "ytt-ytdlp-test-"));
+  const outputDir = path.join(fixtureDir, "audio");
+  const logPath = path.join(fixtureDir, "calls.log");
+  const fakeYtdlpPath = path.join(fixtureDir, "yt-dlp.cjs");
+  const previousYtdlpPath = process.env.YTDLP_PATH;
+  const previousLogPath = process.env.YTDLP_TEST_LOG;
+
+  t.after(async () => {
+    if (previousYtdlpPath === undefined) delete process.env.YTDLP_PATH;
+    else process.env.YTDLP_PATH = previousYtdlpPath;
+    if (previousLogPath === undefined) delete process.env.YTDLP_TEST_LOG;
+    else process.env.YTDLP_TEST_LOG = previousLogPath;
+    await rm(fixtureDir, { recursive: true, force: true });
+  });
+
+  await writeFile(
+    fakeYtdlpPath,
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const path = require("node:path");
+const args = process.argv.slice(2);
+fs.appendFileSync(process.env.YTDLP_TEST_LOG, JSON.stringify(args) + "\\n");
+if (!args.includes("-f")) {
+  console.error("ERROR: unable to download video data: HTTP Error 403: Forbidden");
+  process.exit(1);
+}
+const outputTemplate = args[args.indexOf("-o") + 1];
+const outputPath = outputTemplate.replace("%(ext)s", "mp3");
+fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+fs.writeFileSync(outputPath, "fake audio");
+`,
+  );
+  await chmod(fakeYtdlpPath, 0o755);
+
+  process.env.YTDLP_PATH = fakeYtdlpPath;
+  process.env.YTDLP_TEST_LOG = logPath;
+  const { downloadAudio } = await import("../lib/whisper.js");
+
+  const audioPath = await downloadAudio("UIEzt1gGCmk", outputDir);
+
+  assert.equal(audioPath, path.join(outputDir, "UIEzt1gGCmk.mp3"));
+  const calls = (await readFile(logPath, "utf8"))
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line) as string[]);
+  assert.equal(calls.length, 2);
+  assert.equal(calls[0].includes("-f"), false);
+  assert.deepEqual(calls[1].slice(0, 2), ["-f", "18"]);
+});


### PR DESCRIPTION
First, thank you for building and sharing such a useful tool. The local setup and transcription workflow are thoughtfully put together.

## Why

Some public YouTube videos expose metadata normally, but yt-dlp's default audio-only DASH stream fails at download time with HTTP 403. For the reproduced video (UIEzt1gGCmk), YouTube's progressive format 18 downloads successfully, so the video is still transcribable.

Previously, downloadAudio surfaced the first 403 immediately and Whisper never ran.

## What changed

- Keep the existing audio-only download path as the default.
- Only when that path returns HTTP 403, retry once with progressive format 18 and extract its audio as MP3.
- If the fallback also fails, classify and report that final error through the existing error path.
- Add a regression test with a fake yt-dlp executable that rejects the first call with HTTP 403 and succeeds only when the second call includes -f 18.
- Document the user-facing fix in the changelog.

This is intentionally narrow: it does not change yt-dlp player clients or format selection for downloads that already work.

## Verification

- PATH=/opt/homebrew/opt/node@24/bin:$PATH node --import tsx --test tests/whisper-download.test.ts
- PATH=/opt/homebrew/opt/node@24/bin:$PATH npm run lint (0 errors; one existing no-img-element warning)
- PATH=/opt/homebrew/opt/node@24/bin:$PATH npm run build
- Prettier check for tests/whisper-download.test.ts
